### PR TITLE
return column names in the order requested

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,14 +103,15 @@ To parse parquet files from a user drag-and-drop action, see example in [index.h
 
 To read large parquet files, it is recommended that you filter by row and column.
 Hyparquet is designed to load only the minimal amount of data needed to fulfill a query.
-You can filter rows by number, or columns by name:
+You can filter rows by number, or columns by name,
+and columns will be returned in the same order they were requested:
 
 ```js
 import { parquetRead } from 'hyparquet'
 
 await parquetRead({
   file,
-  columns: ['colA', 'colB'], // include columns colA and colB
+  columns: ['colB', 'colA'], // include columns colB and colA
   rowStart: 100,
   rowEnd: 200,
   onComplete: data => console.log(data),

--- a/src/read.js
+++ b/src/read.js
@@ -190,7 +190,8 @@ export async function readRowGroup(options, rowGroup, groupStart, rowLimit) {
     const includedColumnNames = children
       .map(child => child.element.name)
       .filter(name => !columns || columns.includes(name))
-    const includedColumns = (columns || includedColumnNames)
+    const columnOrder = columns || includedColumnNames
+    const includedColumns = columnOrder
       .map(name => includedColumnNames.includes(name) ? subcolumnData.get(name) : undefined)
 
     for (let row = 0; row < rowLimit; row++) {
@@ -198,7 +199,7 @@ export async function readRowGroup(options, rowGroup, groupStart, rowLimit) {
         // return each row as an object
         /** @type {Record<string, any>} */
         const rowData = {}
-        includedColumnNames.forEach((name, index) => {
+        columnOrder.forEach((name, index) => {
           rowData[name] = includedColumns[index]?.[row]
         })
         groupData[row] = rowData

--- a/src/read.js
+++ b/src/read.js
@@ -190,8 +190,8 @@ export async function readRowGroup(options, rowGroup, groupStart, rowLimit) {
     const includedColumnNames = children
       .map(child => child.element.name)
       .filter(name => !columns || columns.includes(name))
-    const includedColumns = includedColumnNames
-      .map(name => subcolumnData.get(name))
+    const includedColumns = (columns || includedColumnNames)
+      .map(name => includedColumnNames.includes(name) ? subcolumnData.get(name) : undefined)
 
     for (let row = 0; row < rowLimit; row++) {
       if (options.rowFormat === 'object') {
@@ -199,12 +199,12 @@ export async function readRowGroup(options, rowGroup, groupStart, rowLimit) {
         /** @type {Record<string, any>} */
         const rowData = {}
         includedColumnNames.forEach((name, index) => {
-          rowData[name] = includedColumns[index][row]
+          rowData[name] = includedColumns[index]?.[row]
         })
         groupData[row] = rowData
       } else {
         // return each row as an array
-        groupData[row] = includedColumns.map(column => column[row])
+        groupData[row] = includedColumns.map(column => column?.[row])
       }
     }
     return groupData


### PR DESCRIPTION
Resolves #26

Edge cases:

- row requested multiple times: row is returned multiple times
- non-existing row requested: undefined returned