### PR TITLE
Export additional types

### DIFF
--- a/src/hyparquet.d.ts
+++ b/src/hyparquet.d.ts
@@ -1,6 +1,6 @@
-import type { AsyncBuffer, Compressors, FileMetaData, SchemaTree } from './types.d.ts'
+import type { AsyncBuffer, CompressionCodec, Compressors, ConvertedType, FileMetaData, LogicalType, ParquetType, SchemaTree } from './types.d.ts'
 
-export type { AsyncBuffer, Compressors, FileMetaData, SchemaTree }
+export type { AsyncBuffer, CompressionCodec, Compressors, ConvertedType, FileMetaData, LogicalType, ParquetType, SchemaTree }
 
 /**
  * Read parquet data rows from a file-like object.


### PR DESCRIPTION
PR adds some additional types that are exported to use in downstream applications. Our use case is a parquet importer into a database and these were the types we used in some utility functions, and so having them available at the top level would be nice, vs importing from `hyparquet/src/types`.