### PR TITLE
Fix CI by using pinned typescript version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - run: npm i
-      - run: tsc
+      - run: npx tsc
 
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
We can upgrade typescript and fix errors on our own timeline, but should use pinned typescript version for reproducibility.
