### PR TITLE
Query filter

### DIFF
--- a/src/query.js
+++ b/src/query.js
@@ -1,5 +1,6 @@
 import { parquetReadObjects } from './hyparquet.js'
 import { parquetMetadataAsync } from './metadata.js'
+import { equals } from './utils.js'
 
 /**
  * Wraps parquetRead with filter and orderBy support.
@@ -128,7 +129,7 @@ export function matchQuery(record, query = {}) {
     const value = record[field]
 
     if (condition !== null && typeof condition !== 'object') {
-      return value === condition
+      return equals(value, condition)
     }
 
     return Object.entries(condition || {}).every(([operator, target]) => {

--- a/src/query.js
+++ b/src/query.js
@@ -2,17 +2,19 @@ import { parquetReadObjects } from './hyparquet.js'
 import { parquetMetadataAsync } from './metadata.js'
 
 /**
- * Wraps parquetRead with orderBy support.
+ * Wraps parquetRead with filter and orderBy support.
  * This is a parquet-aware query engine that can read a subset of rows and columns.
- * Accepts an optional orderBy column name to sort the results.
+ * Accepts optional filter object to filter the results and orderBy column name to sort the results.
  * Note that using orderBy may SIGNIFICANTLY increase the query time.
  *
- * @param {ParquetReadOptions & { orderBy?: string }} options
+ * @import {ParquetQueryFilter} from '../src/types.d.ts'
+ * @param {ParquetReadOptions & { filter?: ParquetQueryFilter, orderBy?: string }} options
  * @returns {Promise<Record<string, any>[]>} resolves when all requested rows and columns are parsed
  */
 export async function parquetQuery(options) {
-  const { file, rowStart, rowEnd, orderBy } = options
+  const { file, rowStart, rowEnd, orderBy, filter } = options
   options.metadata ||= await parquetMetadataAsync(file)
+  let results
 
   // TODO: Faster path for: no orderBy, no rowStart/rowEnd, one row group
 
@@ -26,11 +28,15 @@ export async function parquetQuery(options) {
       .slice(rowStart, rowEnd)
 
     const sparseData = await parquetReadRows({ ...options, rows: sortedIndices })
-    const data = sortedIndices.map(index => sparseData[index])
-    return data
+    results = sortedIndices.map(index => sparseData[index])
   } else {
-    return await parquetReadObjects(options)
+    results = await parquetReadObjects(options)
   }
+
+  // TODO: Move filter to parquetRead for performance
+  return filter
+    ? results.filter(row => matchQuery(row, filter))
+    : results
 }
 
 /**
@@ -97,4 +103,53 @@ function compare(a, b) {
   if (a < b) return -1
   if (a > b) return 1
   return 1 // TODO: how to handle nulls?
+}
+
+/**
+ * Match a record against a query filter
+ *
+ * @param {any} record
+ * @param {ParquetQueryFilter} query
+ * @returns {boolean}
+ * @example matchQuery({ id: 1 }, { id: {$gte: 1} }) // true
+ */
+export function matchQuery(record, query = {}) {
+  if (query.$and) {
+    return query.$and.every(subQuery => matchQuery(record, subQuery))
+  }
+
+  if (query.$or) {
+    return query.$or.some(subQuery => matchQuery(record, subQuery))
+  }
+
+  return Object.entries(query).every(([field, condition]) => {
+    const value = record[field]
+
+    if (condition !== null && typeof condition !== 'object') {
+      return value === condition
+    }
+
+    return Object.entries(condition || {}).every(([operator, target]) => {
+      switch (operator) {
+      case '$gt':
+        return value > target
+      case '$gte':
+        return value >= target
+      case '$lt':
+        return value < target
+      case '$lte':
+        return value <= target
+      case '$ne':
+        return value !== target
+      case '$in':
+        return Array.isArray(target) && target.includes(value)
+      case '$nin':
+        return Array.isArray(target) && !target.includes(value)
+      case '$not':
+        return !matchQuery({ [field]: value }, { [field]: target })
+      default:
+        return true
+      }
+    })
+  })
 }

--- a/src/query.js
+++ b/src/query.js
@@ -117,6 +117,11 @@ function compare(a, b) {
  * @example matchQuery({ id: 1 }, { id: {$gte: 1} }) // true
  */
 export function matchQuery(record, query = {}) {
+
+  if (query.$not) {
+    return !matchQuery(record, query.$not)
+  }
+
   if (query.$and) {
     return query.$and.every(subQuery => matchQuery(record, subQuery))
   }
@@ -128,8 +133,8 @@ export function matchQuery(record, query = {}) {
   return Object.entries(query).every(([field, condition]) => {
     const value = record[field]
 
-    if (condition !== null && typeof condition !== 'object') {
-      return equals(value, condition)
+    if (condition !== null && (Array.isArray(condition) || typeof condition !== "object")) {
+      return equals(value, condition);
     }
 
     return Object.entries(condition || {}).every(([operator, target]) => {
@@ -148,8 +153,6 @@ export function matchQuery(record, query = {}) {
         return Array.isArray(target) && target.includes(value)
       case '$nin':
         return Array.isArray(target) && !target.includes(value)
-      case '$not':
-        return !matchQuery({ [field]: value }, { [field]: target })
       default:
         return true
       }

--- a/src/query.js
+++ b/src/query.js
@@ -133,8 +133,8 @@ export function matchQuery(record, query = {}) {
   return Object.entries(query).every(([field, condition]) => {
     const value = record[field]
 
-    if (condition !== null && (Array.isArray(condition) || typeof condition !== "object")) {
-      return equals(value, condition);
+    if (condition !== null && (Array.isArray(condition) || typeof condition !== 'object')) {
+      return equals(value, condition)
     }
 
     return Object.entries(condition || {}).every(([operator, target]) => {
@@ -148,11 +148,13 @@ export function matchQuery(record, query = {}) {
       case '$lte':
         return value <= target
       case '$ne':
-        return value !== target
+        return !equals(value, target)
       case '$in':
         return Array.isArray(target) && target.includes(value)
       case '$nin':
         return Array.isArray(target) && !target.includes(value)
+      case '$not':
+        return !matchQuery({ [field]: value }, { [field]: target })
       default:
         return true
       }

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -350,3 +350,22 @@ export interface ParquetReadOptions {
   compressors?: Compressors // custom decompressors
   utf8?: boolean // decode byte arrays as utf8 strings (default true)
 }
+
+type ParquetQueryValue = string | number | boolean | object | null;
+
+export type ParquetQueryOperator = {
+  $gt?: ParquetQueryValue;
+  $gte?: ParquetQueryValue;
+  $lt?: ParquetQueryValue;
+  $lte?: ParquetQueryValue;
+  $ne?: ParquetQueryValue;
+  $in?: ParquetQueryValue[];
+  $nin?: ParquetQueryValue[];
+  $not?: ParquetQueryOperator;
+}
+
+export interface ParquetQueryFilter {
+  [key: string]: ParquetQueryValue | ParquetQueryOperator | ParquetQueryFilter[] | undefined;
+  $and?: ParquetQueryFilter[];
+  $or?: ParquetQueryFilter[];
+}

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -351,21 +351,21 @@ export interface ParquetReadOptions {
   utf8?: boolean // decode byte arrays as utf8 strings (default true)
 }
 
-type ParquetQueryValue = string | number | boolean | object | null;
+export type ParquetQueryValue = string | number | boolean | object | null | undefined
 
 export type ParquetQueryOperator = {
-  $gt?: ParquetQueryValue;
-  $gte?: ParquetQueryValue;
-  $lt?: ParquetQueryValue;
-  $lte?: ParquetQueryValue;
-  $ne?: ParquetQueryValue;
-  $in?: ParquetQueryValue[];
-  $nin?: ParquetQueryValue[];
-  $not?: ParquetQueryOperator;
+  $gt?: ParquetQueryValue
+  $gte?: ParquetQueryValue
+  $lt?: ParquetQueryValue
+  $lte?: ParquetQueryValue
+  $ne?: ParquetQueryValue
+  $in?: ParquetQueryValue[]
+  $nin?: ParquetQueryValue[]
+  $not?: ParquetQueryOperator
 }
 
 export interface ParquetQueryFilter {
-  [key: string]: ParquetQueryValue | ParquetQueryOperator | ParquetQueryFilter[] | undefined;
-  $and?: ParquetQueryFilter[];
-  $or?: ParquetQueryFilter[];
+  [key: string]: ParquetQueryValue | ParquetQueryOperator | ParquetQueryFilter[] | undefined
+  $and?: ParquetQueryFilter[]
+  $or?: ParquetQueryFilter[]
 }

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -361,11 +361,11 @@ export type ParquetQueryOperator = {
   $ne?: ParquetQueryValue
   $in?: ParquetQueryValue[]
   $nin?: ParquetQueryValue[]
-  $not?: ParquetQueryOperator
 }
 
 export interface ParquetQueryFilter {
   [key: string]: ParquetQueryValue | ParquetQueryOperator | ParquetQueryFilter[] | undefined
   $and?: ParquetQueryFilter[]
   $or?: ParquetQueryFilter[]
+  $not?: ParquetQueryFilter
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -39,17 +39,17 @@ export function concat(aaa, bbb) {
 
 /**
  * Deep equality comparison
- * 
- * @param {any} a 
- * @param {any} b 
- * @returns {boolean}
+ *
+ * @param {any} a First object to compare
+ * @param {any} b Second object to compare
+ * @returns {boolean} true if objects are equal
  */
 export function equals(a, b) {
-  if (a === b) return true;
-  if (!a || !b || typeof a !== typeof b) return false;
-  return Array.isArray(a) 
+  if (a === b) return true
+  if (!a || !b || typeof a !== typeof b) return false
+  return Array.isArray(a)
     ? a.length === b.length && a.every((v, i) => equals(v, b[i]))
-    : Object.keys(a).length === Object.keys(b).length && Object.keys(a).every(k => equals(a[k], b[k]));
+    : Object.keys(a).length === Object.keys(b).length && Object.keys(a).every(k => equals(a[k], b[k]))
 }
 
 /**

--- a/src/utils.js
+++ b/src/utils.js
@@ -46,10 +46,11 @@ export function concat(aaa, bbb) {
  */
 export function equals(a, b) {
   if (a === b) return true
+  if (a instanceof Uint8Array && b instanceof Uint8Array) return equals(Array.from(a), Array.from(b))
   if (!a || !b || typeof a !== typeof b) return false
-  return Array.isArray(a)
+  return Array.isArray(a) && Array.isArray(b)
     ? a.length === b.length && a.every((v, i) => equals(v, b[i]))
-    : Object.keys(a).length === Object.keys(b).length && Object.keys(a).every(k => equals(a[k], b[k]))
+    : typeof a === 'object' && Object.keys(a).length === Object.keys(b).length && Object.keys(a).every(k => equals(a[k], b[k]))
 }
 
 /**

--- a/src/utils.js
+++ b/src/utils.js
@@ -38,6 +38,21 @@ export function concat(aaa, bbb) {
 }
 
 /**
+ * Deep equality comparison
+ * 
+ * @param {any} a 
+ * @param {any} b 
+ * @returns {boolean}
+ */
+export function equals(a, b) {
+  if (a === b) return true;
+  if (!a || !b || typeof a !== typeof b) return false;
+  return Array.isArray(a) 
+    ? a.length === b.length && a.every((v, i) => equals(v, b[i]))
+    : Object.keys(a).length === Object.keys(b).length && Object.keys(a).every(k => equals(a[k], b[k]));
+}
+
+/**
  * Get the byte length of a URL using a HEAD request.
  * If requestInit is provided, it will be passed to fetch.
  *

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -83,4 +83,10 @@ describe('parquetQuery', () => {
     ])
   })
 
+  it('reads data with filter, orderBy, and rowStart/rowEnd', async () => {
+    const file = await asyncBufferFromFile('test/files/datapage_v2.snappy.parquet')
+    const rows = await parquetQuery({ file, filter: { c: 2 }, orderBy: 'b', rowStart: 1, rowEnd: 2 })
+    expect(toJson(rows)).toEqual([ { __index__: 4, a: 'abc', b: 5, c: 2, d: true, e: [ 1, 2 ] } ])
+  })
+
 })

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -117,4 +117,82 @@ describe('parquetQuery', () => {
     ])
   })
 
+  it('reads data with $not value filter', async () => {
+    const file = await asyncBufferFromFile('test/files/datapage_v2.snappy.parquet')
+    const rows = await parquetQuery({ file, filter: { c: { $not: 2 } } })
+    expect(toJson(rows)).toEqual([
+      { a: 'abc', b: 2, c: 3, d: true },
+      { a: 'abc', b: 3, c: 4, d: true },
+      { a: null, b: 4, c: 5, d: false, e: [1, 2, 3] },
+    ])
+  })
+
+  it('reads data with $gt filter', async () => {
+    const file = await asyncBufferFromFile('test/files/datapage_v2.snappy.parquet')
+    const rows = await parquetQuery({ file, filter: { b: { $gt: 3 } } })
+    expect(toJson(rows)).toEqual([
+      { a: null, b: 4, c: 5, d: false, e: [1, 2, 3] },
+      { a: 'abc', b: 5, c: 2, d: true, e: [1, 2] },
+    ])
+  })
+
+
+  it('reads data with $gte filter', async () => {
+    const file = await asyncBufferFromFile('test/files/datapage_v2.snappy.parquet')
+    const rows = await parquetQuery({ file, filter: { b: { $gte: 3 } } })
+    expect(toJson(rows)).toEqual([
+      { a: 'abc', b: 3, c: 4, d: true },
+      { a: null, b: 4, c: 5, d: false, e: [1, 2, 3] },
+      { a: 'abc', b: 5, c: 2, d: true, e: [1, 2] },
+    ])
+  })
+
+  it('reads data with $lt filter', async () => {
+    const file = await asyncBufferFromFile('test/files/datapage_v2.snappy.parquet')
+    const rows = await parquetQuery({ file, filter: { b: { $lt: 3 } } })
+    expect(toJson(rows)).toEqual([
+      { a: 'abc', b: 1, c: 2, d: true, e: [1, 2, 3] },
+      { a: 'abc', b: 2, c: 3, d: true },
+    ])
+  })
+
+  it('reads data with $lte filter', async () => {
+    const file = await asyncBufferFromFile('test/files/datapage_v2.snappy.parquet')
+    const rows = await parquetQuery({ file, filter: { b: { $lte: 3 } } })
+    expect(toJson(rows)).toEqual([
+      { a: 'abc', b: 1, c: 2, d: true, e: [1, 2, 3] },
+      { a: 'abc', b: 2, c: 3, d: true },
+      { a: 'abc', b: 3, c: 4, d: true },
+    ])
+  })
+
+  it('reads data with $ne filter', async () => {
+    const file = await asyncBufferFromFile('test/files/datapage_v2.snappy.parquet')
+    const rows = await parquetQuery({ file, filter: { b: { $ne: 3 } } })
+    expect(toJson(rows)).toEqual([
+      { a: 'abc', b: 1, c: 2, d: true, e: [1, 2, 3] },
+      { a: 'abc', b: 2, c: 3, d: true },
+      { a: null, b: 4, c: 5, d: false, e: [1, 2, 3] },
+      { a: 'abc', b: 5, c: 2, d: true, e: [1, 2] },
+    ])
+  })
+
+  it('reads data with $in filter', async () => {
+    const file = await asyncBufferFromFile('test/files/datapage_v2.snappy.parquet')
+    const rows = await parquetQuery({ file, filter: { b: { $in: [2, 4] } } })
+    expect(toJson(rows)).toEqual([
+      { a: 'abc', b: 2, c: 3, d: true },
+      { a: null, b: 4, c: 5, d: false, e: [1, 2, 3] },
+    ])
+  })
+
+  it('reads data with $nin filter', async () => {
+    const file = await asyncBufferFromFile('test/files/datapage_v2.snappy.parquet')
+    const rows = await parquetQuery({ file, filter: { b: { $nin: [2, 4] } } })
+    expect(toJson(rows)).toEqual([
+      { a: 'abc', b: 1, c: 2, d: true, e: [1, 2, 3] },
+      { a: 'abc', b: 3, c: 4, d: true },
+      { a: 'abc', b: 5, c: 2, d: true, e: [1, 2] },
+    ])
+  })
 })

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -78,15 +78,15 @@ describe('parquetQuery', () => {
     const file = await asyncBufferFromFile('test/files/datapage_v2.snappy.parquet')
     const rows = await parquetQuery({ file, filter: { c: 2 }, orderBy: 'b' })
     expect(toJson(rows)).toEqual([
-      { __index__: 0, a: 'abc', b: 1, c: 2, d: true, e: [1, 2, 3] },
-      { __index__: 4, a: 'abc', b: 5, c: 2, d: true, e: [1, 2] },
+      { a: 'abc', b: 1, c: 2, d: true, e: [1, 2, 3] },
+      { a: 'abc', b: 5, c: 2, d: true, e: [1, 2] },
     ])
   })
 
   it('reads data with filter, orderBy, and rowStart/rowEnd', async () => {
     const file = await asyncBufferFromFile('test/files/datapage_v2.snappy.parquet')
     const rows = await parquetQuery({ file, filter: { c: 2 }, orderBy: 'b', rowStart: 1, rowEnd: 2 })
-    expect(toJson(rows)).toEqual([ { __index__: 4, a: 'abc', b: 5, c: 2, d: true, e: [ 1, 2 ] } ])
+    expect(toJson(rows)).toEqual([ { a: 'abc', b: 5, c: 2, d: true, e: [ 1, 2 ] } ])
   })
 
 })

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { parquetQuery } from '../src/query.js'
+import { matchQuery, parquetQuery } from '../src/query.js'
 import { asyncBufferFromFile, toJson } from '../src/utils.js'
 
 describe('parquetQuery', () => {
@@ -61,32 +61,49 @@ describe('parquetQuery', () => {
 
   it('reads data with filter', async () => {
     const file = await asyncBufferFromFile('test/files/datapage_v2.snappy.parquet')
-    const rows = await parquetQuery({ file, filter: { c: 2 } })
-    expect(toJson(rows)).toEqual([
-      { a: 'abc', b: 1, c: 2, d: true, e: [1, 2, 3] },
-      { a: 'abc', b: 5, c: 2, d: true, e: [1, 2] },
-    ])
+    const data = await parquetQuery({ file })
+    const query = { filter: { c: 2 } }
+    const expected = data.filter(row => matchQuery(row, query.filter))
+
+    const rows = await parquetQuery({ file, ...query })
+    expect(toJson(rows)).toEqual(expected)
   })
 
   it('reads data with filter and rowStart/rowEnd', async () => {
     const file = await asyncBufferFromFile('test/files/datapage_v2.snappy.parquet')
-    const rows = await parquetQuery({ file, filter: { c: 2 }, rowStart: 1, rowEnd: 5 })
-    expect(toJson(rows)).toEqual([ { a: 'abc', b: 5, c: 2, d: true, e: [ 1, 2 ] } ])
+    const data = await parquetQuery({ file })
+    const query = { filter: { c: 2 }, rowStart: 1, rowEnd: 5 }
+    const expected = data
+      .filter(row => matchQuery(row, query.filter))
+      .slice(query.rowStart, query.rowEnd)
+
+    const rows = await parquetQuery({ file, ...query })
+    expect(toJson(rows)).toEqual(expected)
   })
 
   it('reads data with filter and orderBy', async () => {
     const file = await asyncBufferFromFile('test/files/datapage_v2.snappy.parquet')
-    const rows = await parquetQuery({ file, filter: { c: 2 }, orderBy: 'b' })
-    expect(toJson(rows)).toEqual([
-      { a: 'abc', b: 1, c: 2, d: true, e: [1, 2, 3] },
-      { a: 'abc', b: 5, c: 2, d: true, e: [1, 2] },
-    ])
+    const data = await parquetQuery({ file })
+    const query = { filter: { c: 2 }, orderBy: 'b' }
+    const expected = data
+      .filter(row => matchQuery(row, query.filter))
+      .sort((a, b) => a[query.orderBy] - b[query.orderBy])
+
+    const rows = await parquetQuery({ file, ...query })
+    expect(toJson(rows)).toEqual(expected)
   })
 
   it('reads data with filter, orderBy, and rowStart/rowEnd', async () => {
     const file = await asyncBufferFromFile('test/files/datapage_v2.snappy.parquet')
-    const rows = await parquetQuery({ file, filter: { c: 2 }, orderBy: 'b', rowStart: 1, rowEnd: 2 })
-    expect(toJson(rows)).toEqual([ { a: 'abc', b: 5, c: 2, d: true, e: [ 1, 2 ] } ])
+    const data = await parquetQuery({ file })
+    const query = { filter: { c: 2 }, orderBy: 'b', rowStart: 1, rowEnd: 2 }
+    const expected = data
+      .filter(row => matchQuery(row, query.filter))
+      .sort((a, b) => a[query.orderBy] - b[query.orderBy])
+      .slice(query.rowStart, query.rowEnd)
+
+    const rows = await parquetQuery({ file, ...query })
+    expect(toJson(rows)).toEqual(expected)
   })
 
 })

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { matchQuery, parquetQuery } from '../src/query.js'
+import { parquetQuery } from '../src/query.js'
 import { asyncBufferFromFile, toJson } from '../src/utils.js'
 
 describe('parquetQuery', () => {
@@ -61,49 +61,60 @@ describe('parquetQuery', () => {
 
   it('reads data with filter', async () => {
     const file = await asyncBufferFromFile('test/files/datapage_v2.snappy.parquet')
-    const data = await parquetQuery({ file })
-    const query = { filter: { c: 2 } }
-    const expected = data.filter(row => matchQuery(row, query.filter))
-
-    const rows = await parquetQuery({ file, ...query })
-    expect(toJson(rows)).toEqual(expected)
+    const rows = await parquetQuery({ file, filter: { c: 2 } })
+    expect(toJson(rows)).toEqual([
+      { a: 'abc', b: 1, c: 2, d: true, e: [ 1, 2, 3 ] },
+      { a: 'abc', b: 5, c: 2, d: true, e: [ 1, 2 ] },
+    ])
   })
 
   it('reads data with filter and rowStart/rowEnd', async () => {
     const file = await asyncBufferFromFile('test/files/datapage_v2.snappy.parquet')
-    const data = await parquetQuery({ file })
-    const query = { filter: { c: 2 }, rowStart: 1, rowEnd: 5 }
-    const expected = data
-      .filter(row => matchQuery(row, query.filter))
-      .slice(query.rowStart, query.rowEnd)
-
-    const rows = await parquetQuery({ file, ...query })
-    expect(toJson(rows)).toEqual(expected)
+    const rows = await parquetQuery({ file, filter: { c: 2 }, rowStart: 1, rowEnd: 5 })
+    expect(toJson(rows)).toEqual([ { a: 'abc', b: 5, c: 2, d: true, e: [ 1, 2 ] } ])
   })
 
   it('reads data with filter and orderBy', async () => {
     const file = await asyncBufferFromFile('test/files/datapage_v2.snappy.parquet')
-    const data = await parquetQuery({ file })
-    const query = { filter: { c: 2 }, orderBy: 'b' }
-    const expected = data
-      .filter(row => matchQuery(row, query.filter))
-      .sort((a, b) => a[query.orderBy] - b[query.orderBy])
-
-    const rows = await parquetQuery({ file, ...query })
-    expect(toJson(rows)).toEqual(expected)
+    const rows = await parquetQuery({ file, filter: { c: 2 }, orderBy: 'b' })
+    expect(toJson(rows)).toEqual([
+      { a: 'abc', b: 1, c: 2, d: true, e: [ 1, 2, 3 ] },
+      { a: 'abc', b: 5, c: 2, d: true, e: [ 1, 2 ] },
+    ])
   })
 
   it('reads data with filter, orderBy, and rowStart/rowEnd', async () => {
     const file = await asyncBufferFromFile('test/files/datapage_v2.snappy.parquet')
-    const data = await parquetQuery({ file })
-    const query = { filter: { c: 2 }, orderBy: 'b', rowStart: 1, rowEnd: 2 }
-    const expected = data
-      .filter(row => matchQuery(row, query.filter))
-      .sort((a, b) => a[query.orderBy] - b[query.orderBy])
-      .slice(query.rowStart, query.rowEnd)
+    const rows = await parquetQuery({ file, filter: { c: 2 }, orderBy: 'b', rowStart: 1, rowEnd: 2 })
+    expect(toJson(rows)).toEqual([ { a: 'abc', b: 5, c: 2, d: true, e: [ 1, 2 ] } ])
+  })
 
-    const rows = await parquetQuery({ file, ...query })
-    expect(toJson(rows)).toEqual(expected)
+  it('reads data with $and filter', async () => {
+    const file = await asyncBufferFromFile('test/files/datapage_v2.snappy.parquet')
+    const rows = await parquetQuery({ file, filter: { $and: [{ c: 2 }, { e: [1, 2, 3] }] } })
+    expect(toJson(rows)).toEqual([
+      { a: 'abc', b: 1, c: 2, d: true, e: [1, 2, 3] },
+    ])
+  })
+
+  it('reads data with $or filter', async () => {
+    const file = await asyncBufferFromFile('test/files/datapage_v2.snappy.parquet')
+    const rows = await parquetQuery({ file, filter: { $or: [{ c: 2 }, { d: false }] } })
+    expect(toJson(rows)).toEqual([
+      { a: 'abc', b: 1, c: 2, d: true, e: [1, 2, 3] },
+      { a: null, b: 4, c: 5, d: false, e: [1, 2, 3] },
+      { a: 'abc', b: 5, c: 2, d: true, e: [1, 2] },
+    ])
+  })
+
+  it('reads data with $not filter', async () => {
+    const file = await asyncBufferFromFile('test/files/datapage_v2.snappy.parquet')
+    const rows = await parquetQuery({ file, filter: { $not: { c: 2 } } })
+    expect(toJson(rows)).toEqual([
+      { a: 'abc', b: 2, c: 3, d: true },
+      { a: 'abc', b: 3, c: 4, d: true },
+      { a: null, b: 4, c: 5, d: false, e: [1, 2, 3] },
+    ])
   })
 
 })

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -58,4 +58,29 @@ describe('parquetQuery', () => {
     const futureRows = parquetQuery({ file, orderBy: 'nonexistent' })
     await expect(futureRows).rejects.toThrow('parquet columns not found: nonexistent')
   })
+
+  it('reads data with filter', async () => {
+    const file = await asyncBufferFromFile('test/files/datapage_v2.snappy.parquet')
+    const rows = await parquetQuery({ file, filter: { c: 2 } })
+    expect(toJson(rows)).toEqual([
+      { a: 'abc', b: 1, c: 2, d: true, e: [1, 2, 3] },
+      { a: 'abc', b: 5, c: 2, d: true, e: [1, 2] },
+    ])
+  })
+
+  it('reads data with filter and rowStart/rowEnd', async () => {
+    const file = await asyncBufferFromFile('test/files/datapage_v2.snappy.parquet')
+    const rows = await parquetQuery({ file, filter: { c: 2 }, rowStart: 1, rowEnd: 5 })
+    expect(toJson(rows)).toEqual([ { a: 'abc', b: 5, c: 2, d: true, e: [ 1, 2 ] } ])
+  })
+
+  it('reads data with filter and orderBy', async () => {
+    const file = await asyncBufferFromFile('test/files/datapage_v2.snappy.parquet')
+    const rows = await parquetQuery({ file, filter: { c: 2 }, orderBy: 'b' })
+    expect(toJson(rows)).toEqual([
+      { __index__: 0, a: 'abc', b: 1, c: 2, d: true, e: [1, 2, 3] },
+      { __index__: 4, a: 'abc', b: 5, c: 2, d: true, e: [1, 2] },
+    ])
+  })
+
 })


### PR DESCRIPTION
This is a preliminary implementation of a filter interface for the parquetQuery function. In this inital pull request, we've implemented filters as a post-processing step. We plan to integrate filters into the data fetching pipeline to execute efficient queries against large files. 

The filter interface uses mongo query syntax. For example:

|Query|Description|
|-|-|
|{ key: value }                      | Exact match |
|{ key: { $gt: value } }             | Greater than |
|{ key: { $gte: value } }            | Greater than or equal |
|{ key: { $lt: value } }             | Less than |
|{ key: { $lte: value } }            | Less than or equal |
|{ key: { $ne: value } }             | Not equal |
|{ key: { $in: [value1, value2] } }  | Matches any value in array |
|{ key: { $nin: [value1, value2] } } | Does not match values in array |
|{ key: { $gte: minValue, $lte: maxValue } } | Inclusive Between |
|{ $and: [{ key1: "value1" }, { key2: "value2" }] } | Logical And |
|{ $or: [{ key1: "value1" }, { key2: "value2" }] }  | Logical Or |
|{ key: { $not: { $gt: value } } }   | Negates a query condition |