### PR TITLE
Support endpoints that don't support range requests in `asyncBufferFromUrl`

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -98,7 +98,7 @@ export async function asyncBufferFromUrl({ url, byteLength, requestInit }) {
     byteLength,
     async slice(start, end) {
       if (buffer) {
-        return buffer.then(buffer => buffer.slice(start, end));
+        return buffer.then(buffer => buffer.slice(start, end))
       }
 
       const headers = new Headers(init.headers)
@@ -107,21 +107,21 @@ export async function asyncBufferFromUrl({ url, byteLength, requestInit }) {
 
       const res = await fetch(url, { ...init, headers })
       if (!res.ok || !res.body) throw new Error(`fetch failed ${res.status}`)
-      
+
       switch (res.status) {
-        // Endpoint does not support range requests and returned the whole object
-        case 200:
-          buffer = res.arrayBuffer();
-          return buffer.then(buffer => buffer.slice(start, end));
+      // Endpoint does not support range requests and returned the whole object
+      case 200:
+        buffer = res.arrayBuffer()
+        return buffer.then(buffer => buffer.slice(start, end))
 
         // The endpoint supports range requests and sent us the requested range
-        case 206:
-          return res.arrayBuffer();
+      case 206:
+        return res.arrayBuffer()
 
-        default:
-          throw new Error(`fetch received unexpected status code ${res.status}`)
+      default:
+        throw new Error(`fetch received unexpected status code ${res.status}`)
       }
-    }
+    },
   }
 }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -108,17 +108,14 @@ export async function asyncBufferFromUrl({ url, byteLength, requestInit }) {
       const res = await fetch(url, { ...init, headers })
       if (!res.ok || !res.body) throw new Error(`fetch failed ${res.status}`)
 
-      switch (res.status) {
-      // Endpoint does not support range requests and returned the whole object
-      case 200:
+      if (res.status === 200) {
+        // Endpoint does not support range requests and returned the whole object
         buffer = res.arrayBuffer()
         return buffer.then(buffer => buffer.slice(start, end))
-
+      } else if (res.status === 206) {
         // The endpoint supports range requests and sent us the requested range
-      case 206:
         return res.arrayBuffer()
-
-      default:
+      } else {
         throw new Error(`fetch received unexpected status code ${res.status}`)
       }
     },

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,6 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
 import { asyncBufferFromUrl, byteLengthFromUrl, toJson } from '../src/utils.js'
-import { arrayBuffer } from 'stream/consumers'
 
 describe('toJson', () => {
   it('convert undefined to null', () => {
@@ -208,7 +207,7 @@ describe('asyncBufferFromUrl', () => {
     await expect(withHeaders.slice(0, 10)).rejects.toThrow('fetch failed 404')
   })
 
-  describe("when range requests are unsupported", () => {
+  describe('when range requests are unsupported', () => {
     it('creates an AsyncBuffer with the correct byte length', async () => {
       const mockArrayBuffer = new ArrayBuffer(1024)
       global.fetch = vi.fn().mockResolvedValue({
@@ -216,16 +215,16 @@ describe('asyncBufferFromUrl', () => {
         status: 200,
         body: {},
         arrayBuffer: () => Promise.resolve(mockArrayBuffer),
-      });
-  
+      })
+
       const buffer = await asyncBufferFromUrl({ url: 'https://example.com', byteLength: 1024 })
-      const chunk = await buffer.slice(0, 100);
-  
+      const chunk = await buffer.slice(0, 100)
+
       expect(fetch).toHaveBeenCalledWith('https://example.com', {
-        headers: new Headers({ Range: 'bytes=0-99' })
-      });
-  
-      expect(chunk.byteLength).toBe(100);
+        headers: new Headers({ Range: 'bytes=0-99' }),
+      })
+
+      expect(chunk.byteLength).toBe(100)
     })
 
     it('does not make multiple requests for multiple slices', async () => {
@@ -234,8 +233,8 @@ describe('asyncBufferFromUrl', () => {
         ok: true,
         status: 200,
         body: {},
-        arrayBuffer: () => Promise.resolve(mockArrayBuffer)
-      });
+        arrayBuffer: () => Promise.resolve(mockArrayBuffer),
+      })
 
       const buffer = await asyncBufferFromUrl({ url: 'https://example.com', byteLength: 1024 })
 


### PR DESCRIPTION
Hey! We've been using hyparquet to parse some parquet files stored behind an endpoint that doesn't support range requests. This is possible to do with a custom `file` object but only works with `asyncBufferFromUrl` if the relevant file is in the browser cache which leads to some confusing "works on my machine" issues. It would be nicer if `asyncBufferFromUrl` just worked correctly in this case and that's what I've done in this PR.

Before this commit `asyncBufferFromUrl` assumes that the body of whatever successful response it gets is equivalent to the range it requested. If the origin server does not support HTTP range requests then this assumption is usually wrong and will lead to parsing failures.

This commit changes `asyncBufferFromUrl` to change its behaviour slightly based on the status code in the response:
- if 200 then we got the whole parquet file as the response. Save it and use the resulting ArrayBuffer to serve all future slice calls.
- if 206 then we got a range response and we can just return that.

I have also included some test cases to ensure that such responses are handled correctly and also tweaked other existing mocks to include the relevant status code.

The one case where this code isn't fully correct is the case of multiple concurrent calls to `slice`. It'll work fine if the origin supports range requests, but might end up making extra unnecessary requests if it doesn't. I scanned `readGroup` and I don't think it ever makes concurrent slice calls so I don't think this is an issue. I am, however, happy to fix it if you guys think it is worth doing so.