### PR TITLE
Added condtional type to improve typing in case of object row format

### DIFF
--- a/src/hyparquet.js
+++ b/src/hyparquet.js
@@ -16,8 +16,8 @@ export { asyncBufferFromFile, asyncBufferFromUrl, byteLengthFromUrl, cachedAsync
 export function parquetReadObjects(options) {
   return new Promise((onComplete, reject) => {
     parquetRead({
-      rowFormat: 'object',
       ...options,
+      rowFormat: 'object',
       onComplete,
     }).catch(reject)
   })

--- a/src/hyparquet.js
+++ b/src/hyparquet.js
@@ -10,7 +10,7 @@ export { snappyUncompress } from './snappy.js'
 export { asyncBufferFromFile, asyncBufferFromUrl, byteLengthFromUrl, cachedAsyncBuffer, toJson } from './utils.js'
 
 /**
- * @param {ParquetReadOptions} options
+ * @param {ParquetReadObjectsOptions} options
  * @returns {Promise<Record<string, any>[]>} resolves when all requested rows and columns are parsed
 */
 export function parquetReadObjects(options) {
@@ -59,4 +59,5 @@ export function parquetReadObjects(options) {
  * @typedef {import('../src/types.d.ts').BoundaryOrder} BoundaryOrder
  * @typedef {import('../src/types.d.ts').ColumnData} ColumnData
  * @typedef {import('../src/types.d.ts').ParquetReadOptions} ParquetReadOptions
+ * @typedef {import('../src/types.d.ts').ParquetReadObjectsOptions} ParquetReadObjectsOptions
  */

--- a/src/hyparquet.js
+++ b/src/hyparquet.js
@@ -16,8 +16,8 @@ export { asyncBufferFromFile, asyncBufferFromUrl, byteLengthFromUrl, cachedAsync
 export function parquetReadObjects(options) {
   return new Promise((onComplete, reject) => {
     parquetRead({
-      ...options,
       rowFormat: 'object',
+      ...options,
       onComplete,
     }).catch(reject)
   })

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -338,6 +338,8 @@ export interface ColumnData {
 /**
  * Parquet query options for reading data
  */
+
+export type ParquetReadObjectsOptions = ParquetBaseReadOptions & {rowFormat?: 'object'}
 export type ParquetReadOptions = ParquetBaseReadOptions & ParquetRowReadCallbacks
 
 type ParquetRowReadCallbacks = 
@@ -353,6 +355,7 @@ interface ParquetBaseReadOptions {
   onChunk?: (chunk: ColumnData) => void // called when a column chunk is parsed. chunks may be outside the requested range.
   compressors?: Compressors // custom decompressors
   utf8?: boolean // decode byte arrays as utf8 strings (default true)
+  rowFormat? : 'array' | 'object' // format of each row passed to the onComplete function
 }
 
 interface ParquetRowReadOnCompleteArray {

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -338,7 +338,7 @@ export interface ColumnData {
 /**
  * Parquet query options for reading data
  */
-export type ParquetReadOptions =  ParquetBaseReadOptions | ParquetObjectRowReadOptions
+export type ParquetReadOptions =  ParquetArrayRowReadOptions | ParquetObjectRowReadOptions
 
 interface ParquetBaseReadOptions {
   file: AsyncBuffer // file-like object containing parquet data
@@ -347,9 +347,13 @@ interface ParquetBaseReadOptions {
   rowStart?: number // first requested row index (inclusive)
   rowEnd?: number // last requested row index (exclusive)
   onChunk?: (chunk: ColumnData) => void // called when a column chunk is parsed. chunks may be outside the requested range.
-  onComplete?: (rows: any[][]) => void // called when all requested rows and columns are parsed
   compressors?: Compressors // custom decompressors
   utf8?: boolean // decode byte arrays as utf8 strings (default true)
+}
+
+interface ParquetArrayRowReadOptions extends ParquetBaseReadOptions {
+  rowFormat?: "array" // format of each row passed to the onComplete function
+  onComplete?: (rows: any[][]) => void // called when all requested rows and columns are parsed
 }
 
 interface ParquetObjectRowReadOptions extends ParquetBaseReadOptions {

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -338,7 +338,11 @@ export interface ColumnData {
 /**
  * Parquet query options for reading data
  */
-export type ParquetReadOptions =  ParquetArrayRowReadOptions | ParquetObjectRowReadOptions
+export type ParquetReadOptions = ParquetBaseReadOptions & ParquetRowReadCallbacks
+
+type ParquetRowReadCallbacks = 
+  | ParquetRowReadOnCompleteArray
+  | ParquetRowReadOnCompleteObject
 
 interface ParquetBaseReadOptions {
   file: AsyncBuffer // file-like object containing parquet data
@@ -351,14 +355,14 @@ interface ParquetBaseReadOptions {
   utf8?: boolean // decode byte arrays as utf8 strings (default true)
 }
 
-interface ParquetArrayRowReadOptions extends ParquetBaseReadOptions {
-  rowFormat?: "array" // format of each row passed to the onComplete function
+interface ParquetRowReadOnCompleteArray {
+  rowFormat?: 'array' // format of each row passed to the onComplete function
   onComplete?: (rows: any[][]) => void // called when all requested rows and columns are parsed
 }
 
-interface ParquetObjectRowReadOptions extends ParquetBaseReadOptions {
-  rowFormat: "object" // format of each row passed to the onComplete function
-  onComplete?: (rows: any[]) => void // called when all requested rows and columns are parsed
+interface ParquetRowReadOnCompleteObject {
+  rowFormat: 'object' // format of each row passed to the onComplete function
+  onComplete?: (rows: Record<string, any>[]) => void // called when all requested rows and columns are parsed 
 }
 
 export type ParquetQueryValue = string | number | boolean | object | null | undefined

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -338,17 +338,23 @@ export interface ColumnData {
 /**
  * Parquet query options for reading data
  */
-export interface ParquetReadOptions {
+export type ParquetReadOptions =  ParquetBaseReadOptions | ParquetObjectRowReadOptions
+
+interface ParquetBaseReadOptions {
   file: AsyncBuffer // file-like object containing parquet data
   metadata?: FileMetaData // parquet metadata, will be parsed if not provided
   columns?: string[] // columns to read, all columns if undefined
-  rowFormat?: string // format of each row passed to the onComplete function
   rowStart?: number // first requested row index (inclusive)
   rowEnd?: number // last requested row index (exclusive)
   onChunk?: (chunk: ColumnData) => void // called when a column chunk is parsed. chunks may be outside the requested range.
   onComplete?: (rows: any[][]) => void // called when all requested rows and columns are parsed
   compressors?: Compressors // custom decompressors
   utf8?: boolean // decode byte arrays as utf8 strings (default true)
+}
+
+interface ParquetObjectRowReadOptions extends ParquetBaseReadOptions {
+  rowFormat: "object" // format of each row passed to the onComplete function
+  onComplete?: (rows: any[]) => void // called when all requested rows and columns are parsed
 }
 
 export type ParquetQueryValue = string | number | boolean | object | null | undefined

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -339,7 +339,7 @@ export interface ColumnData {
  * Parquet query options for reading data
  */
 
-export type ParquetReadObjectsOptions = ParquetBaseReadOptions & {rowFormat?: 'object'}
+export type ParquetReadObjectsOptions = Omit<ParquetBaseReadOptions, 'rowFormat'>
 export type ParquetReadOptions = ParquetBaseReadOptions & ParquetRowReadCallbacks
 
 type ParquetRowReadCallbacks = 

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -7,5 +7,5 @@
     "outDir": "types",
     "declarationMap": true
   },
-  "include": ["src"]
+  "include": ["src", "test"]
 }


### PR DESCRIPTION
Hello,
when using the `rowFormat: "object"` the type for rows in the `onComplete` still is `any[][]`. It should be `any[]`. 
This PR converts the interface to a type and thus makes it possible to use conditional types.
With this change the type definition of `onComplete` changes depending on if `rowFormat` is set to object.

Have a great day!
Mario