### PR TITLE
Return typed arrays in onChunk

### DIFF
--- a/src/assemble.js
+++ b/src/assemble.js
@@ -104,7 +104,7 @@ export function assembleLists(
  * https://github.com/apache/parquet-format/blob/apache-parquet-format-2.10.0/LogicalTypes.md#nested-types
  *
  * @import {SchemaTree} from '../src/types.d.ts'
- * @param {Map<string, any[]>} subcolumnData
+ * @param {Map<string, DecodedArray>} subcolumnData
  * @param {SchemaTree} schema top-level schema element
  * @param {number} [depth] depth of nested structure
  */
@@ -180,7 +180,7 @@ export function assembleNested(subcolumnData, schema, depth = 0) {
 }
 
 /**
- * @param {any[]} arr
+ * @param {DecodedArray} arr
  * @param {number} depth
  */
 function flattenAtDepth(arr, depth) {
@@ -194,8 +194,8 @@ function flattenAtDepth(arr, depth) {
 }
 
 /**
- * @param {any[]} keys
- * @param {any[]} values
+ * @param {DecodedArray} keys
+ * @param {DecodedArray} values
  * @param {number} depth
  * @returns {any[]}
  */

--- a/test/column.test.js
+++ b/test/column.test.js
@@ -9,9 +9,9 @@ const values = [null, 1, -2, NaN, 0, -1, -0, 2]
 
 describe('readColumn', () => {
   it.for([
-    { rowLimit: undefined, expected: values },
-    { rowLimit: Infinity, expected: values },
-    { rowLimit: 2, expected: values.slice(0, 2) },
+    { rowLimit: undefined, expected: [values] },
+    { rowLimit: Infinity, expected: [values] },
+    { rowLimit: 2, expected: [values.slice(0, 2)] },
     { rowLimit: 0, expected: [] },
   ])('readColumn with rowLimit %p', async ({ rowLimit, expected }) => {
     const testFile = 'test/files/float16_nonzeros_and_nans.parquet'
@@ -28,5 +28,22 @@ describe('readColumn', () => {
 
     const result = readColumn(reader, rowLimit, column.meta_data, schemaPath, { file: asyncBuffer, compressors })
     expect(result).toEqual(expected)
+  })
+
+  it('readColumn should return a typed array', async () => {
+    const testFile = 'test/files/datapage_v2.snappy.parquet'
+    const asyncBuffer = await asyncBufferFromFile(testFile)
+    const arrayBuffer = await asyncBuffer.slice(0)
+    const metadata = parquetMetadata(arrayBuffer)
+
+    const column = metadata.row_groups[0].columns[1] // second column
+    if (!column.meta_data) throw new Error(`No column metadata for ${testFile}`)
+    const [columnStartByte, columnEndByte] = getColumnRange(column.meta_data).map(Number)
+    const columnArrayBuffer = arrayBuffer.slice(columnStartByte, columnEndByte)
+    const schemaPath = getSchemaPath(metadata.schema, column.meta_data?.path_in_schema ?? [])
+    const reader = { view: new DataView(columnArrayBuffer), offset: 0 }
+
+    const columnData = readColumn(reader, Infinity, column.meta_data, schemaPath, { file: asyncBuffer, compressors })
+    expect(columnData[0]).toBeInstanceOf(Int32Array)
   })
 })

--- a/test/read.test.js
+++ b/test/read.test.js
@@ -41,7 +41,7 @@ describe('parquetRead', () => {
     })
   })
 
-  it('read a single column', async () => {
+  it('read a single column as typed array', async () => {
     const file = await asyncBufferFromFile('test/files/datapage_v2.snappy.parquet')
     await parquetRead({
       file,
@@ -49,11 +49,11 @@ describe('parquetRead', () => {
       onChunk(chunk) {
         expect(chunk).toEqual({
           columnName: 'b',
-          columnData: [1, 2, 3, 4, 5],
+          columnData: new Int32Array([1, 2, 3, 4, 5]),
           rowStart: 0,
           rowEnd: 5,
         })
-        expect(chunk.columnData).toBeInstanceOf(Array)
+        expect(chunk.columnData).toBeInstanceOf(Int32Array)
       },
     })
   })


### PR DESCRIPTION
Return typed arrays (Int32Array, etc) from `onChunk`.

Fixes #65 thanks @mjmdavis

Refactored `readColumn` so that instead of using `concat` to join all the column data into one giant array, `readColumn` now returns a list of lists `DecodedArray[]`. This allows us to avoid many `concat` operations. Less copying and less memory allocation results in faster parsing!

<img width="1436" alt="Screenshot 2025-03-10 at 23 14 21" src="https://github.com/user-attachments/assets/d5c5074a-c160-40e9-b5c5-20d2c5a614bd" />

If anyone was using `readColumn` directly, they might need to now flatten the return value.