### PR TITLE
Map src to types with package exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,16 @@
   ],
   "type": "module",
   "types": "types/hyparquet.d.ts",
+  "exports": {
+    ".": {
+      "import": "./src/hyparquet.js",
+      "types": "./types/hyparquet.d.ts"
+    },
+    "./src/*.js": {
+      "import": "./src/*.js",
+      "types": "./types/*.d.ts"
+    }
+  },
   "scripts": {
     "build:types": "tsc -p ./tsconfig.build.json",
     "coverage": "vitest run --coverage --coverage.include=src",


### PR DESCRIPTION
This _should_ fix #69 but want to get your thoughts @severo 

From my research there were two ways to fix this. The first was typescript-specific and felt more hacky:

```js
  "typesVersions": {
    "*": {
      "src/*": ["types/*"]
    }
  },
  ```

It seemed like the better way was to explicitly define package `exports` and associate types with the default exports vs file exports:

```js
  "exports": {
    ".": {
      "types": "./types/hyparquet.d.ts",
      "import": "./src/hyparquet.js"
    },
    "./src/*.js": {
      "types": "./types/*.d.ts",
      "import": "./src/*.js"
    }
  },
  ```

There was also some choice between `"import"` and `"default"` but since we only export ESM modules, import seemed like the right choice.

I tested these locally with `npm pack` and dependency on `"hyparquet": "../hyparquet/hyparquet-1.9.1.tgz",`. It appears to fix the type issue in #69.

Finally, I'll probably publish this as `1.9.2` because this is a type fix, not an API change? I could be convinced if you think it should be `1.10.0` though? (I wouldn't be surprised if this breaks something and someone subesquently files an issue due to unforeseen build process).