### PR TITLE
types must be the first element

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,12 +30,12 @@
   "types": "types/hyparquet.d.ts",
   "exports": {
     ".": {
-      "import": "./src/hyparquet.js",
-      "types": "./types/hyparquet.d.ts"
+      "types": "./types/hyparquet.d.ts",
+      "import": "./src/hyparquet.js"
     },
     "./src/*.js": {
-      "import": "./src/*.js",
-      "types": "./types/*.d.ts"
+      "types": "./types/*.d.ts",
+      "import": "./src/*.js"
     }
   },
   "scripts": {

--- a/test/package.test.js
+++ b/test/package.test.js
@@ -21,4 +21,11 @@ describe('package.json', () => {
     expect('dependencies' in packageJson).toBe(false)
     expect('peerDependencies' in packageJson).toBe(false)
   })
+  it('should have exports with types first', () => {
+    const { exports } = packageJson
+    expect(exports).toBeDefined()
+    for (const [, exportObj] of Object.entries(exports)) {
+      expect(Object.keys(exportObj)).toEqual(['types', 'import'])
+    }
+  })
 })

--- a/test/package.test.js
+++ b/test/package.test.js
@@ -25,7 +25,11 @@ describe('package.json', () => {
     const { exports } = packageJson
     expect(exports).toBeDefined()
     for (const [, exportObj] of Object.entries(exports)) {
-      expect(Object.keys(exportObj)).toEqual(['types', 'import'])
+      if (typeof exportObj === 'object') {
+        expect(Object.keys(exportObj)).toEqual(['types', 'import'])
+      } else {
+        expect(typeof exportObj).toBe('string')
+      }
     }
   })
 })


### PR DESCRIPTION
You can check with https://publint.dev/hyparquet@1.12.1 or `npx publint`:

Before:

```
Running publint v0.3.12 for hyparquet...
Packing files with `npm pack`...
Linting...
Errors:
1. pkg.exports["."].types should be the first in the object as conditions are order-sensitive so it can be resolved by TypeScript.
2. pkg.exports["./src/*.js"].types should be the first in the object as conditions are order-sensitive so it can be resolved by TypeScript.
Warnings:
1. pkg.exports["."].import types is not exported. Consider adding pkg.exports["."].import.types: "./types/hyparquet.d.ts" to be compatible with TypeScript's "moduleResolution": "bundler" compiler option.
2. pkg.exports["."].types types is interpreted as ESM when resolving with the "require" condition. This causes the types to only work when dynamically importing the package, even though the package exports CJS. Consider splitting out two "types" conditions for "import" and "require", and use the .cts extension, e.g. pkg.exports["."].require.types: "./types/hyparquet.d.cts"
```

After:

```
Running publint v0.3.12 for hyparquet...
Packing files with `npm pack`...
Linting...
All good!
```