### PR TITLE
Fast filter by loading each row group and filtering until rowEnd

### DIFF
--- a/src/read.js
+++ b/src/read.js
@@ -9,12 +9,10 @@ import { concat } from './utils.js'
  * Read parquet data rows from a file-like object.
  * Reads the minimal number of row groups and columns to satisfy the request.
  *
- * Returns a void promise when complete, and to throw errors.
- * Data is returned in onComplete, not the return promise, because
- * if onComplete is undefined, we parse the data, and emit chunks, but skip
- * computing the row view directly. This saves on allocation if the caller
- * wants to cache the full chunks, and make their own view of the data from
- * the chunks.
+ * Returns a void promise when complete.
+ * Errors are thrown on the returned promise.
+ * Data is returned in callbacks onComplete, onChunk, onPage, NOT the return promise.
+ * See parquetReadObjects for a more convenient API.
  *
  * @param {ParquetReadOptions} options read options
  * @returns {Promise<void>} resolves when all requested rows and columns are parsed, all errors are thrown here
@@ -27,7 +25,7 @@ export async function parquetRead(options) {
   // load metadata if not provided
   options.metadata ??= await parquetMetadataAsync(options.file)
   const { metadata, onComplete, rowStart = 0, rowEnd } = options
-  if (rowStart < 0) throw new Error('parquetRead rowStart must be postive')
+  if (rowStart < 0) throw new Error('parquetRead rowStart must be positive')
 
   // prefetch byte ranges
   const plan = parquetPlan(options)

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -27,14 +27,16 @@ export function reader(bytes) {
  *
  * @import {AsyncBuffer} from '../src/types.js'
  * @param {AsyncBuffer} asyncBuffer
- * @returns {AsyncBuffer & {fetches: number}}
+ * @returns {AsyncBuffer & {fetches: number, bytes: number}}
  */
 export function countingBuffer(asyncBuffer) {
   return {
     ...asyncBuffer,
     fetches: 0,
+    bytes: 0,
     slice(start, end) {
       this.fetches++
+      this.bytes += (end ?? asyncBuffer.byteLength) - start
       return asyncBuffer.slice(start, end)
     },
   }

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -21,3 +21,21 @@ export function fileToJson(filePath) {
 export function reader(bytes) {
   return { view: new DataView(new Uint8Array(bytes).buffer), offset: 0 }
 }
+
+/**
+ * Wraps an AsyncBuffer to count the number of fetches made
+ *
+ * @import {AsyncBuffer} from '../src/types.js'
+ * @param {AsyncBuffer} asyncBuffer
+ * @returns {AsyncBuffer & {fetches: number}}
+ */
+export function countingBuffer(asyncBuffer) {
+  return {
+    ...asyncBuffer,
+    fetches: 0,
+    slice(start, end) {
+      this.fetches++
+      return asyncBuffer.slice(start, end)
+    },
+  }
+}

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -206,6 +206,8 @@ describe('parquetQuery', () => {
       { row: 32n, quality: 'good' },
       { row: 37n, quality: 'good' },
     ])
-    expect(file.fetches).toBe(2)
+    // if we weren't streaming row groups, this would be 3:
+    expect(file.fetches).toBe(2) // 1 metadata, 1 row group
+    expect(file.bytes).toBe(5261)
   })
 })

--- a/test/read.test.js
+++ b/test/read.test.js
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest'
 import { convertWithDictionary } from '../src/convert.js'
 import { parquetMetadataAsync, parquetRead, parquetReadObjects } from '../src/hyparquet.js'
 import { asyncBufferFromFile } from '../src/utils.js'
+import { countingBuffer } from './helpers.js'
 
 vi.mock('../src/convert.js', { spy: true })
 
@@ -184,7 +185,7 @@ describe('parquetRead', () => {
 
   it('reads individual pages', async () => {
     const file = countingBuffer(await asyncBufferFromFile('test/files/page_indexed.parquet'))
-    /** @type {ColumnData[]} */
+    /** @type {import('../src/types.js').ColumnData[]} */
     const pages = []
 
     // check onPage callback
@@ -252,22 +253,3 @@ describe('parquetRead', () => {
     expect(file.fetches).toBe(3) // 1 metadata, 2 rowgroups
   })
 })
-
-/**
- * Wraps an AsyncBuffer to count the number of fetches made
- *
- * @import {AsyncBuffer, ColumnData} from '../src/types.js'
- * @param {AsyncBuffer} asyncBuffer
- * @returns {AsyncBuffer & {fetches: number}}
- */
-
-function countingBuffer(asyncBuffer) {
-  return {
-    ...asyncBuffer,
-    fetches: 0,
-    slice(start, end) {
-      this.fetches++
-      return asyncBuffer.slice(start, end)
-    },
-  }
-}

--- a/test/read.test.js
+++ b/test/read.test.js
@@ -251,5 +251,6 @@ describe('parquetRead', () => {
       expect(page).toEqual(expected)
     }
     expect(file.fetches).toBe(3) // 1 metadata, 2 rowgroups
+    expect(file.bytes).toBe(6421)
   })
 })


### PR DESCRIPTION
This change _substantially_ improves performance on a certain kind of query:

```js
const filter =  { $gte: { l_quantity: 50 } } // or whatever
const rows = await parquetQuery({ file, filter, rowEnd: 1000 })
```

What's important is that, especially for the table viewer use case, you'll want to apply a `filter` and then apply a row window. Often you'll want the first rows 0 to 30... in that case you really shouldn't fetch all the data unless you have to.

So this PR changes the (admittedly naive) implementation from `fetch all rows and filter` to `fetch each row group and filter until we have accumulated enough rows to satisfy rowEnd`.

In the case where you are filtering (but not sorting) a parquet file, and looking at the first N results, this will _usually_ result in reading only one row group of data (unless the filter is sparse or the file has only one row group 😭 ).

On the `hyparquet-perf` tpch benchmark this results in an improvement from 6200ms to 180ms on a filtered+windowed query. 🚀 

Includes a test that would have been 3 fetches on master but is 2 round-trip fetches on this branch.