### PR TITLE
Node-specific exports for asyncBufferFromFile

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,19 +47,6 @@ Check out a minimal parquet viewer demo that shows how to integrate hyparquet in
 
 ## Quick Start
 
-### Node.js Example
-
-To read the contents of a local parquet file in a node.js environment use `asyncBufferFromFile`:
-
-```javascript
-const { asyncBufferFromFile, parquetReadObjects } = await import('hyparquet')
-
-const file = await asyncBufferFromFile(filename)
-const data = await parquetReadObjects({ file })
-```
-
-Note: hyparquet is published as an ES module, so dynamic `import()` may be required on the command line.
-
 ### Browser Example
 
 In the browser use `asyncBufferFromUrl` to wrap a url for reading asynchronously over the network.
@@ -77,6 +64,20 @@ const data = await parquetReadObjects({
   rowEnd: 20,
 })
 ```
+
+### Node.js Example
+
+To read the contents of a local parquet file in a node.js environment use `asyncBufferFromFile`:
+
+```javascript
+const { parquetReadObjects } = await import('hyparquet')
+const { asyncBufferFromFile } = await import('hyparquet/node')
+
+const file = await asyncBufferFromFile(filename)
+const data = await parquetReadObjects({ file })
+```
+
+Note: hyparquet is published as an ES module, so dynamic `import()` may be required on the command line for old versions of node.
 
 ## Parquet Writing
 
@@ -124,15 +125,6 @@ interface AsyncBuffer {
 
 In most cases, you should probably use `asyncBufferFromUrl` or `asyncBufferFromFile` to create an `AsyncBuffer` for hyparquet.
 
-#### asyncBufferFromFile
-
-If you are in a local node.js environment, use `asyncBufferFromFile` to wrap a local file as an `AsyncBuffer`:
-
-```typescript
-const file: AsyncBuffer = asyncBufferFromFile('local.parquet')
-const data = await parquetReadObjects({ file })
-```
-
 #### asyncBufferFromUrl
 
 If you want to read a parquet file remotely over http, use `asyncBufferFromUrl` to wrap an http url as an `AsyncBuffer` using http range requests.
@@ -147,6 +139,20 @@ const byteLength = 415958713 // optional
 const file: AsyncBuffer = await asyncBufferFromUrl({ url, requestInit, byteLength })
 const data = await parquetReadObjects({ file })
 ```
+
+#### asyncBufferFromFile
+
+If you are in a local node.js environment, use `asyncBufferFromFile` to wrap a local file as an `AsyncBuffer`:
+
+```typescript
+import { parquetReadObjects } from 'hyparquet'
+import { asyncBufferFromFile } from 'hyparquet/node'
+
+const file: AsyncBuffer = await asyncBufferFromFile('local.parquet')
+const data = await parquetReadObjects({ file })
+```
+
+> Update v1.15.0+: `asyncBufferFromFile` was moved from `hyparquet` to `hyparquet/node`. This is to avoid bundling node-specific code into browser bundles.
 
 #### ArrayBuffer
 
@@ -252,7 +258,6 @@ You can include support for ALL parquet `compressors` plus hysnappy using the [h
 import { parquetReadObjects } from 'hyparquet'
 import { compressors } from 'hyparquet-compressors'
 
-const file = await asyncBufferFromFile(filename)
 const data = await parquetReadObjects({ file, compressors })
 ```
 

--- a/README.md
+++ b/README.md
@@ -70,14 +70,13 @@ const data = await parquetReadObjects({
 To read the contents of a local parquet file in a node.js environment use `asyncBufferFromFile`:
 
 ```javascript
-const { parquetReadObjects } = await import('hyparquet')
-const { asyncBufferFromFile } = await import('hyparquet/node')
+const { asyncBufferFromFile, parquetReadObjects } = await import('hyparquet')
 
-const file = await asyncBufferFromFile(filename)
+const file = await asyncBufferFromFile('example.parquet')
 const data = await parquetReadObjects({ file })
 ```
 
-Note: hyparquet is published as an ES module, so dynamic `import()` may be required on the command line for old versions of node.
+Note: hyparquet is published as an ES module, so dynamic `import()` may be required for old versions of node.
 
 ## Parquet Writing
 
@@ -142,17 +141,14 @@ const data = await parquetReadObjects({ file })
 
 #### asyncBufferFromFile
 
-If you are in a local node.js environment, use `asyncBufferFromFile` to wrap a local file as an `AsyncBuffer`:
+If you are in a node.js environment, use `asyncBufferFromFile` to wrap a local file as an `AsyncBuffer`:
 
 ```typescript
-import { parquetReadObjects } from 'hyparquet'
-import { asyncBufferFromFile } from 'hyparquet/node'
+import { asyncBufferFromFile, parquetReadObjects } from 'hyparquet'
 
-const file: AsyncBuffer = await asyncBufferFromFile('local.parquet')
+const file: AsyncBuffer = await asyncBufferFromFile('example.parquet')
 const data = await parquetReadObjects({ file })
 ```
-
-> Update v1.15.0+: `asyncBufferFromFile` was moved from `hyparquet` to `hyparquet/node`. This is to avoid bundling node-specific code into browser bundles.
 
 #### ArrayBuffer
 

--- a/package.json
+++ b/package.json
@@ -26,17 +26,18 @@
     "types"
   ],
   "type": "module",
-  "types": "./types/hyparquet.d.ts",
-  "main": "./src/hyparquet.js",
-  "browser": "./src/hyparquet.js",
+  "types": "types/hyparquet.d.ts",
+  "main": "src/hyparquet.js",
   "exports": {
     ".": {
-      "types": "./types/hyparquet.d.ts",
-      "import": "./src/hyparquet.js"
-    },
-    "./node": {
-      "types": "./types/node.d.ts",
-      "import": "./src/node.js"
+      "browser": {
+        "types": "./types/hyparquet.d.ts",
+        "import": "./src/hyparquet.js"
+      },
+      "default": {
+        "types": "./types/node.d.ts",
+        "import": "./src/node.js"
+      }
     },
     "./src/*.js": {
       "types": "./types/*.d.ts",

--- a/package.json
+++ b/package.json
@@ -30,8 +30,14 @@
   "types": "types/hyparquet.d.ts",
   "exports": {
     ".": {
-      "types": "./types/hyparquet.d.ts",
-      "import": "./src/hyparquet.js"
+      "browser": {
+        "types": "./types/hyparquet.d.ts",
+        "import": "./src/hyparquet.js"
+      },
+      "default": {
+        "types": "./types/node.d.ts",
+        "import": "./src/node.js"
+      }
     },
     "./src/*.js": {
       "types": "./types/*.d.ts",

--- a/package.json
+++ b/package.json
@@ -21,23 +21,22 @@
     "type": "git",
     "url": "git+https://github.com/hyparam/hyparquet.git"
   },
-  "main": "src/hyparquet.js",
   "files": [
     "src",
     "types"
   ],
   "type": "module",
-  "types": "types/hyparquet.d.ts",
+  "types": "./types/hyparquet.d.ts",
+  "main": "./src/hyparquet.js",
+  "browser": "./src/hyparquet.js",
   "exports": {
     ".": {
-      "browser": {
-        "types": "./types/hyparquet.d.ts",
-        "import": "./src/hyparquet.js"
-      },
-      "default": {
-        "types": "./types/node.d.ts",
-        "import": "./src/node.js"
-      }
+      "types": "./types/hyparquet.d.ts",
+      "import": "./src/hyparquet.js"
+    },
+    "./node": {
+      "types": "./types/node.d.ts",
+      "import": "./src/node.js"
     },
     "./src/*.js": {
       "types": "./types/*.d.ts",

--- a/src/hyparquet.js
+++ b/src/hyparquet.js
@@ -4,7 +4,7 @@ export { parquetMetadata, parquetMetadataAsync, parquetSchema } from './metadata
 export { parquetRead }
 export { parquetQuery } from './query.js'
 export { snappyUncompress } from './snappy.js'
-export { asyncBufferFromFile, asyncBufferFromUrl, byteLengthFromUrl, cachedAsyncBuffer, flatten, toJson } from './utils.js'
+export { asyncBufferFromUrl, byteLengthFromUrl, cachedAsyncBuffer, flatten, toJson } from './utils.js'
 
 /**
  * This is a helper function to read parquet row data as a promise.

--- a/src/node.js
+++ b/src/node.js
@@ -1,0 +1,38 @@
+import { createReadStream, promises as fs } from 'fs'
+
+export * from './hyparquet.js'
+
+/**
+ * Construct an AsyncBuffer for a local file using node fs package.
+ *
+ * @param {string} filename
+ * @returns {Promise<import('./types.js').AsyncBuffer>}
+ */
+export async function asyncBufferFromFile(filename) {
+  const stat = await fs.stat(filename)
+  return {
+    byteLength: stat.size,
+    async slice(start, end) {
+      // read file slice
+      const readStream = createReadStream(filename, { start, end })
+      return await readStreamToArrayBuffer(readStream)
+    },
+  }
+}
+
+/**
+ * @param {import('stream').Readable} input
+ * @returns {Promise<ArrayBuffer>}
+ */
+function readStreamToArrayBuffer(input) {
+  return new Promise((resolve, reject) => {
+    /** @type {Buffer[]} */
+    const chunks = []
+    input.on('data', chunk => chunks.push(chunk))
+    input.on('end', () => {
+      const buffer = Buffer.concat(chunks)
+      resolve(buffer.buffer.slice(buffer.byteOffset, buffer.byteOffset + buffer.byteLength))
+    })
+    input.on('error', reject)
+  })
+}

--- a/src/node.js
+++ b/src/node.js
@@ -3,37 +3,31 @@ import { createReadStream, promises as fs } from 'fs'
 export * from './hyparquet.js'
 
 /**
+ * @import {AsyncBuffer} from '../src/types.js'
+ */
+/**
  * Construct an AsyncBuffer for a local file using node fs package.
  *
  * @param {string} filename
  * @returns {Promise<AsyncBuffer>}
  */
 export async function asyncBufferFromFile(filename) {
-  const stat = await fs.stat(filename)
+  const { size } = await fs.stat(filename)
   return {
-    byteLength: stat.size,
-    async slice(start, end) {
+    byteLength: size,
+    slice(start, end) {
       // read file slice
-      const readStream = createReadStream(filename, { start, end })
-      return await readStreamToArrayBuffer(readStream)
+      const reader = createReadStream(filename, { start, end })
+      return new Promise((resolve, reject) => {
+        /** @type {any[]} */
+        const chunks = []
+        reader.on('data', chunk => chunks.push(chunk))
+        reader.on('error', reject)
+        reader.on('end', () => {
+          const buffer = Buffer.concat(chunks)
+          resolve(buffer.buffer.slice(buffer.byteOffset, buffer.byteOffset + buffer.byteLength))
+        })
+      })
     },
   }
-}
-
-/**
- * @import {AsyncBuffer} from '../src/types.js'
- * @param {import('stream').Readable} input
- * @returns {Promise<ArrayBuffer>}
- */
-function readStreamToArrayBuffer(input) {
-  return new Promise((resolve, reject) => {
-    /** @type {Buffer[]} */
-    const chunks = []
-    input.on('data', chunk => chunks.push(chunk))
-    input.on('end', () => {
-      const buffer = Buffer.concat(chunks)
-      resolve(buffer.buffer.slice(buffer.byteOffset, buffer.byteOffset + buffer.byteLength))
-    })
-    input.on('error', reject)
-  })
 }

--- a/src/node.js
+++ b/src/node.js
@@ -1,5 +1,7 @@
 import { createReadStream, promises as fs } from 'fs'
 
+export * from './hyparquet.js'
+
 /**
  * Construct an AsyncBuffer for a local file using node fs package.
  *

--- a/src/node.js
+++ b/src/node.js
@@ -1,12 +1,10 @@
 import { createReadStream, promises as fs } from 'fs'
 
-export * from './hyparquet.js'
-
 /**
  * Construct an AsyncBuffer for a local file using node fs package.
  *
  * @param {string} filename
- * @returns {Promise<import('./types.js').AsyncBuffer>}
+ * @returns {Promise<AsyncBuffer>}
  */
 export async function asyncBufferFromFile(filename) {
   const stat = await fs.stat(filename)
@@ -21,6 +19,7 @@ export async function asyncBufferFromFile(filename) {
 }
 
 /**
+ * @import {AsyncBuffer} from '../src/types.js'
  * @param {import('stream').Readable} input
  * @returns {Promise<ArrayBuffer>}
  */

--- a/src/utils.js
+++ b/src/utils.js
@@ -128,45 +128,6 @@ export async function asyncBufferFromUrl({ url, byteLength, requestInit, fetch: 
 }
 
 /**
- * Construct an AsyncBuffer for a local file using node fs package.
- *
- * @param {string} filename
- * @returns {Promise<AsyncBuffer>}
- */
-export async function asyncBufferFromFile(filename) {
-  const fsPackage = 'fs' // webpack no include
-  const fs = await import(fsPackage)
-  const stat = await fs.promises.stat(filename)
-  return {
-    byteLength: stat.size,
-    async slice(start, end) {
-      // read file slice
-      const readStream = fs.createReadStream(filename, { start, end })
-      return await readStreamToArrayBuffer(readStream)
-    },
-  }
-}
-
-/**
- * Convert a node ReadStream to ArrayBuffer.
- *
- * @param {import('stream').Readable} input
- * @returns {Promise<ArrayBuffer>}
- */
-function readStreamToArrayBuffer(input) {
-  return new Promise((resolve, reject) => {
-    /** @type {Buffer[]} */
-    const chunks = []
-    input.on('data', chunk => chunks.push(chunk))
-    input.on('end', () => {
-      const buffer = Buffer.concat(chunks)
-      resolve(buffer.buffer.slice(buffer.byteOffset, buffer.byteOffset + buffer.byteLength))
-    })
-    input.on('error', reject)
-  })
-}
-
-/**
  * Returns a cached layer on top of an AsyncBuffer. For caching slices of a file
  * that are read multiple times, possibly over a network.
  *

--- a/test/column.test.js
+++ b/test/column.test.js
@@ -1,9 +1,9 @@
 import { describe, expect, it } from 'vitest'
 import { readColumn } from '../src/column.js'
 import { parquetMetadata } from '../src/hyparquet.js'
+import { asyncBufferFromFile } from '../src/node.js'
 import { getColumnRange } from '../src/plan.js'
 import { getSchemaPath } from '../src/schema.js'
-import { asyncBufferFromFile } from '../src/utils.js'
 
 const values = [null, 1, -2, NaN, 0, -1, -0, 2]
 

--- a/test/indexes.test.js
+++ b/test/indexes.test.js
@@ -1,9 +1,9 @@
 import fs from 'fs'
 import { describe, expect, it } from 'vitest'
-import { parquetMetadata } from '../src/hyparquet.js'
+import { parquetMetadata, toJson } from '../src/hyparquet.js'
 import { readColumnIndex, readOffsetIndex } from '../src/indexes.js'
+import { asyncBufferFromFile } from '../src/node.js'
 import { getSchemaPath } from '../src/schema.js'
-import { asyncBufferFromFile, toJson } from '../src/node.js'
 import { fileToJson } from './helpers.js'
 
 describe('readColumnIndex', () => {

--- a/test/indexes.test.js
+++ b/test/indexes.test.js
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest'
 import { parquetMetadata } from '../src/hyparquet.js'
 import { readColumnIndex, readOffsetIndex } from '../src/indexes.js'
 import { getSchemaPath } from '../src/schema.js'
-import { asyncBufferFromFile, toJson } from '../src/utils.js'
+import { asyncBufferFromFile, toJson } from '../src/node.js'
 import { fileToJson } from './helpers.js'
 
 describe('readColumnIndex', () => {

--- a/test/metadata.test.js
+++ b/test/metadata.test.js
@@ -1,7 +1,7 @@
 import fs from 'fs'
 import { describe, expect, it } from 'vitest'
 import { parquetMetadata, parquetMetadataAsync } from '../src/hyparquet.js'
-import { asyncBufferFromFile, toJson } from '../src/utils.js'
+import { asyncBufferFromFile, toJson } from '../src/node.js'
 import { fileToJson } from './helpers.js'
 
 const files = fs.readdirSync('test/files').filter(f => f.endsWith('.parquet'))

--- a/test/metadata.test.js
+++ b/test/metadata.test.js
@@ -1,7 +1,7 @@
 import fs from 'fs'
 import { describe, expect, it } from 'vitest'
-import { parquetMetadata, parquetMetadataAsync } from '../src/hyparquet.js'
-import { asyncBufferFromFile, toJson } from '../src/node.js'
+import { parquetMetadata, parquetMetadataAsync, toJson } from '../src/hyparquet.js'
+import { asyncBufferFromFile } from '../src/node.js'
 import { fileToJson } from './helpers.js'
 
 const files = fs.readdirSync('test/files').filter(f => f.endsWith('.parquet'))

--- a/test/package.test.js
+++ b/test/package.test.js
@@ -23,13 +23,12 @@ describe('package.json', () => {
   })
   it('should have exports with types first', () => {
     const { exports } = packageJson
-    expect(exports).toBeDefined()
-    for (const [, exportObj] of Object.entries(exports)) {
-      if (typeof exportObj === 'object') {
-        expect(Object.keys(exportObj)).toEqual(['types', 'import'])
-      } else {
-        expect(typeof exportObj).toBe('string')
-      }
-    }
+    expect(Object.keys(exports)).toEqual(['.', './src/*.js'])
+    // node vs default (browser)
+    expect(Object.keys(exports['.'])).toEqual(['browser', 'default'])
+    expect(Object.keys(exports['.'].browser)).toEqual(['types', 'import'])
+    expect(Object.keys(exports['.'].default)).toEqual(['types', 'import'])
+    // deep imports
+    expect(Object.keys(exports['./src/*.js'])).toEqual(['types', 'import'])
   })
 })

--- a/test/package.test.js
+++ b/test/package.test.js
@@ -23,13 +23,12 @@ describe('package.json', () => {
   })
   it('should have exports with types first', () => {
     const { exports } = packageJson
-    expect(Object.keys(exports)).toEqual(['.', './node', './src/*.js'])
-    for (const [, exportObj] of Object.entries(exports)) {
-      if (typeof exportObj === 'object') {
-        expect(Object.keys(exportObj)).toEqual(['types', 'import'])
-      } else {
-        expect(typeof exportObj).toBe('string')
-      }
-    }
+    expect(Object.keys(exports)).toEqual(['.', './src/*.js'])
+    // node vs default (browser)
+    expect(Object.keys(exports['.'])).toEqual(['browser', 'default'])
+    expect(Object.keys(exports['.'].browser)).toEqual(['types', 'import'])
+    expect(Object.keys(exports['.'].default)).toEqual(['types', 'import'])
+    // deep imports
+    expect(Object.keys(exports['./src/*.js'])).toEqual(['types', 'import'])
   })
 })

--- a/test/package.test.js
+++ b/test/package.test.js
@@ -23,12 +23,13 @@ describe('package.json', () => {
   })
   it('should have exports with types first', () => {
     const { exports } = packageJson
-    expect(Object.keys(exports)).toEqual(['.', './src/*.js'])
-    // node vs default (browser)
-    expect(Object.keys(exports['.'])).toEqual(['browser', 'default'])
-    expect(Object.keys(exports['.'].browser)).toEqual(['types', 'import'])
-    expect(Object.keys(exports['.'].default)).toEqual(['types', 'import'])
-    // deep imports
-    expect(Object.keys(exports['./src/*.js'])).toEqual(['types', 'import'])
+    expect(Object.keys(exports)).toEqual(['.', './node', './src/*.js'])
+    for (const [, exportObj] of Object.entries(exports)) {
+      if (typeof exportObj === 'object') {
+        expect(Object.keys(exportObj)).toEqual(['types', 'import'])
+      } else {
+        expect(typeof exportObj).toBe('string')
+      }
+    }
   })
 })

--- a/test/plan.test.js
+++ b/test/plan.test.js
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { parquetMetadataAsync } from '../src/hyparquet.js'
-import { asyncBufferFromFile } from '../src/utils.js'
+import { asyncBufferFromFile } from '../src/node.js'
 import { parquetPlan } from '../src/plan.js'
 
 describe('parquetPlan', () => {

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { parquetQuery } from '../src/query.js'
-import { asyncBufferFromFile } from '../src/utils.js'
+import { asyncBufferFromFile } from '../src/node.js'
 import { countingBuffer } from './helpers.js'
 
 describe('parquetQuery', () => {

--- a/test/read.test.js
+++ b/test/read.test.js
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 import { convertWithDictionary } from '../src/convert.js'
 import { parquetMetadataAsync, parquetRead, parquetReadObjects } from '../src/hyparquet.js'
-import { asyncBufferFromFile } from '../src/utils.js'
+import { asyncBufferFromFile } from '../src/node.js'
 import { countingBuffer } from './helpers.js'
 
 vi.mock('../src/convert.js', { spy: true })

--- a/test/read.utf8.test.js
+++ b/test/read.utf8.test.js
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { parquetReadObjects } from '../src/hyparquet.js'
-import { asyncBufferFromFile } from '../src/utils.js'
+import { asyncBufferFromFile } from '../src/node.js'
 
 describe('parquetRead utf8', () => {
   it('default utf8 behavior', async () => {

--- a/test/readFiles.test.js
+++ b/test/readFiles.test.js
@@ -2,7 +2,7 @@ import fs from 'fs'
 import { compressors } from 'hyparquet-compressors'
 import { describe, expect, it } from 'vitest'
 import { parquetMetadataAsync, parquetRead } from '../src/hyparquet.js'
-import { asyncBufferFromFile, toJson } from '../src/utils.js'
+import { asyncBufferFromFile, toJson } from '../src/node.js'
 import { fileToJson } from './helpers.js'
 
 describe('parquetRead test files', () => {

--- a/test/readFiles.test.js
+++ b/test/readFiles.test.js
@@ -1,8 +1,8 @@
 import fs from 'fs'
 import { compressors } from 'hyparquet-compressors'
 import { describe, expect, it } from 'vitest'
-import { parquetMetadataAsync, parquetRead } from '../src/hyparquet.js'
-import { asyncBufferFromFile, toJson } from '../src/node.js'
+import { parquetMetadataAsync, parquetRead, toJson } from '../src/hyparquet.js'
+import { asyncBufferFromFile } from '../src/node.js'
 import { fileToJson } from './helpers.js'
 
 describe('parquetRead test files', () => {

--- a/test/schemaTree.test.js
+++ b/test/schemaTree.test.js
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { parquetMetadataAsync, parquetSchema } from '../src/hyparquet.js'
-import { asyncBufferFromFile } from '../src/utils.js'
+import { asyncBufferFromFile } from '../src/node.js'
 
 describe('parquetSchema', () => {
   it('parse schema tree from rowgroups.parquet', async () => {


### PR DESCRIPTION
This PR is an attempt to fix #39

The problem is that `asyncBufferFromFile` depends on node built-in package `fs`, but that won't exist if bundled for the browser. To work around this in the past, I did a hack of dynamically importing `fs` in a way that webpack wouldn't detect. But as @ryan-williams pointed out, this can cause problems with next.js not working on server side routes. :crying_cat_face: 

This PR changes the package exports to have `browser` and `default` and only export `asyncBufferFromFile` in the new `node.js` export file.

I'm nervous to merge this PR as it could have unpredictable effects on downstream users. I tested with local publishing on next, vite, local node, and the browser. But I'm sure there's environments I'm missing. Feedback appreciated!