### PR TITLE
Add more details to QueryPlan

### DIFF
--- a/src/read.js
+++ b/src/read.js
@@ -4,6 +4,9 @@ import { readRowGroup } from './rowgroup.js'
 import { concat } from './utils.js'
 
 /**
+ * @import {ParquetReadOptions} from '../src/types.d.ts'
+ */
+/**
  * Read parquet data rows from a file-like object.
  * Reads the minimal number of row groups and columns to satisfy the request.
  *
@@ -53,7 +56,3 @@ export async function parquetRead(options) {
 
   if (onComplete) onComplete(rowData)
 }
-
-/**
- * @import {DecodedArray, ParquetReadOptions, RowGroup, RowGroupSelect, SchemaTree} from '../src/types.d.ts'
- */

--- a/src/rowgroup.js
+++ b/src/rowgroup.js
@@ -15,12 +15,12 @@ import { flatten } from './utils.js'
 export async function readRowGroup(options, rowGroup, groupStart) {
   const { file, metadata, columns, rowStart = 0, rowEnd } = options
   if (!metadata) throw new Error('parquet metadata not found')
-  const numRows = Number(rowGroup.num_rows)
+  const groupRows = Number(rowGroup.num_rows)
   // indexes within the group to read:
   const selectStart = Math.max(rowStart - groupStart, 0)
-  const selectEnd = Math.min((rowEnd ?? Infinity) - groupStart, numRows)
+  const selectEnd = Math.min((rowEnd ?? Infinity) - groupStart, groupRows)
   /** @type {RowGroupSelect} */
-  const rowGroupSelect = { groupStart, selectStart, selectEnd, numRows }
+  const rowGroupSelect = { groupStart, selectStart, selectEnd, groupRows }
 
   /** @type {Promise<void>[]} */
   const promises = []

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -58,17 +58,6 @@ export interface ByteRange {
   endByte: number // exclusive
 }
 
-/**
- * Query plan for which byte ranges to read.
- */
-export interface QueryPlan {
-  ranges: ByteRange[] // byte ranges to fetch
-  groups: GroupPlan[] // byte ranges by row group
-}
-interface GroupPlan {
-  plan: ByteRange[]
-}
-
 export interface DataReader {
   view: DataView
   offset: number
@@ -393,6 +382,27 @@ export type BoundaryOrder = 'UNORDERED' | 'ASCENDING' | 'DESCENDING'
 export type ThriftObject = { [ key: `field_${number}` ]: ThriftType }
 export type ThriftType = boolean | number | bigint | Uint8Array | ThriftType[] | ThriftObject
 
+/**
+ * Query plan for which byte ranges to read.
+ */
+export interface QueryPlan {
+  metadata: FileMetaData
+  rowStart: number
+  rowEnd?: number
+  columns?: string[] // columns to read
+  fetches: ByteRange[] // byte ranges to fetch
+  groups: GroupPlan[] // byte ranges by row group
+}
+// Plan for one group
+interface GroupPlan {
+  ranges: ByteRange[]
+  rowGroup: RowGroup // row group metadata
+  groupStart: number // row index of the first row in the group
+  selectStart: number // row index in the group to start reading
+  selectEnd: number // row index in the group to stop reading
+  groupRows: number
+}
+
 export interface ColumnDecoder {
   columnName: string
   type: ParquetType
@@ -407,5 +417,5 @@ export interface RowGroupSelect {
   groupStart: number // row index of the first row in the group
   selectStart: number // row index in the group to start reading
   selectEnd: number // row index in the group to stop reading
-  numRows: number
+  groupRows: number
 }

--- a/test/column.test.js
+++ b/test/column.test.js
@@ -35,7 +35,7 @@ describe('readColumn', () => {
       groupStart: 0,
       selectStart: 0,
       selectEnd,
-      numRows: expected.length,
+      groupRows: expected.length,
     }
 
     const result = readColumn(reader, rowGroupSelect, columnDecoder)
@@ -65,7 +65,7 @@ describe('readColumn', () => {
       groupStart: 0,
       selectStart: 0,
       selectEnd: Infinity,
-      numRows: Number(column.meta_data.num_values),
+      groupRows: Number(column.meta_data.num_values),
     }
 
     const columnData = readColumn(reader, rowGroupSelect, columnDecoder)

--- a/test/plan.test.js
+++ b/test/plan.test.js
@@ -8,20 +8,27 @@ describe('parquetPlan', () => {
     const file = await asyncBufferFromFile('test/files/page_indexed.parquet')
     const metadata = await parquetMetadataAsync(file)
     const plan = parquetPlan({ file, metadata })
-    expect(plan).toEqual({
-      ranges: [
+    expect(plan).toMatchObject({
+      metadata,
+      rowStart: 0,
+      rowEnd: 200,
+      fetches: [
         { startByte: 4, endByte: 1166 },
         { startByte: 1166, endByte: 2326 },
       ],
       groups: [
         {
-          plan: [
+          groupRows: 100,
+          groupStart: 0,
+          ranges: [
             { startByte: 4, endByte: 832 },
             { startByte: 832, endByte: 1166 },
           ],
         },
         {
-          plan: [
+          groupRows: 100,
+          groupStart: 100,
+          ranges: [
             { startByte: 1166, endByte: 1998 },
             { startByte: 1998, endByte: 2326 },
           ],


### PR DESCRIPTION
This is preparation for a bigger refactor. It helps to have this data in the plan up-front rather than having to recompute it on the fly deep in the read functions. Having materialized `metadata` means we don't need to check for it everywhere in the code, if we have a plan.

 - Add `metadata` (adds context to the plan)
 - Add `rowStart` and `rowEnd`
 - Add `columns`
 - Add `groupStart`, `selectStart`, `selectEnd`, and `groupRows` to `GroupPlan` (so they don't need to be recomputed later)
 - Rename `ranges` to `fetches` (makes it clearer why this param is different from `ranges` in `GroupPlan`)
 - Rename `numRows` to `groupRows` in ColumnDecoder (this was driving me crazy. technically a breaking change though)
