### PR TITLE
Completely refactor readRowGroup to return AsyncRowGroup

### DIFF
--- a/src/hyparquet.js
+++ b/src/hyparquet.js
@@ -4,7 +4,7 @@ export { parquetMetadata, parquetMetadataAsync, parquetSchema } from './metadata
 export { parquetRead }
 export { parquetQuery } from './query.js'
 export { snappyUncompress } from './snappy.js'
-export { asyncBufferFromFile, asyncBufferFromUrl, byteLengthFromUrl, cachedAsyncBuffer, toJson } from './utils.js'
+export { asyncBufferFromFile, asyncBufferFromUrl, byteLengthFromUrl, cachedAsyncBuffer, flatten, toJson } from './utils.js'
 
 /**
  * This is a helper function to read parquet row data as a promise.

--- a/src/query.js
+++ b/src/query.js
@@ -1,5 +1,6 @@
 import { parquetReadObjects } from './hyparquet.js'
 import { parquetMetadataAsync } from './metadata.js'
+import { parquetReadColumn } from './read.js'
 import { equals } from './utils.js'
 
 /**
@@ -45,11 +46,11 @@ export async function parquetQuery(options) {
     return results.slice(rowStart, rowEnd)
   } else if (typeof orderBy === 'string') {
     // sorted but unfiltered: fetch orderBy column first
-    const orderColumn = await parquetReadObjects({ ...options, rowStart: undefined, rowEnd: undefined, columns: [orderBy] })
+    const orderColumn = await parquetReadColumn({ ...options, rowStart: undefined, rowEnd: undefined, columns: [orderBy] })
 
     // compute row groups to fetch
     const sortedIndices = Array.from(orderColumn, (_, index) => index)
-      .sort((a, b) => compare(orderColumn[a][orderBy], orderColumn[b][orderBy]))
+      .sort((a, b) => compare(orderColumn[a], orderColumn[b]))
       .slice(rowStart, rowEnd)
 
     const sparseData = await parquetReadRows({ ...options, rows: sortedIndices })

--- a/src/rowgroup.js
+++ b/src/rowgroup.js
@@ -5,32 +5,24 @@ import { getSchemaPath } from './schema.js'
 import { flatten } from './utils.js'
 
 /**
+ * @import {AsyncColumn, AsyncRowGroup, DecodedArray, GroupPlan, ParquetReadOptions, QueryPlan, RowGroup, SchemaTree} from './types.js'
+ */
+/**
  * Read a row group from a file-like object.
  *
- * @param {ParquetReadOptions} options read options
- * @param {RowGroup} rowGroup row group to read
- * @param {number} groupStart row index of the first row in the group
- * @returns {Promise<any[][]>} resolves to row data
+ * @param {ParquetReadOptions} options
+ * @param {QueryPlan} plan
+ * @param {GroupPlan} groupPlan
+ * @returns {AsyncRowGroup} resolves to column data
  */
-export async function readRowGroup(options, rowGroup, groupStart) {
-  const { file, metadata, columns, rowStart = 0, rowEnd } = options
-  if (!metadata) throw new Error('parquet metadata not found')
-  const groupRows = Number(rowGroup.num_rows)
-  // indexes within the group to read:
-  const selectStart = Math.max(rowStart - groupStart, 0)
-  const selectEnd = Math.min((rowEnd ?? Infinity) - groupStart, groupRows)
-  /** @type {RowGroupSelect} */
-  const rowGroupSelect = { groupStart, selectStart, selectEnd, groupRows }
+export function readRowGroup(options, { metadata, columns }, groupPlan) {
+  const { file, compressors, utf8 } = options
 
-  /** @type {Promise<void>[]} */
-  const promises = []
-  // top-level columns to assemble
-  const { children } = getSchemaPath(metadata.schema, [])[0]
-  const subcolumnNames = new Map(children.map(child => [child.element.name, getSubcolumns(child)]))
-  /** @type {Map<string, DecodedArray[]>} */
-  const subcolumnData = new Map() // columns to assemble as maps
+  /** @type {AsyncColumn[]} */
+  const asyncColumns = []
+
   // read column data
-  for (const { file_path, meta_data } of rowGroup.columns) {
+  for (const { file_path, meta_data } of groupPlan.rowGroup.columns) {
     if (file_path) throw new Error('parquet file_path not supported')
     if (!meta_data) throw new Error('parquet column metadata is undefined')
 
@@ -54,102 +46,114 @@ export async function readRowGroup(options, rowGroup, groupStart) {
     const buffer = Promise.resolve(file.slice(startByte, endByte))
 
     // read column data async
-    promises.push(buffer.then(arrayBuffer => {
-      const schemaPath = getSchemaPath(metadata.schema, meta_data.path_in_schema)
-      const reader = { view: new DataView(arrayBuffer), offset: 0 }
-      const subcolumn = meta_data.path_in_schema.join('.')
-      const columnDecoder = {
-        columnName: subcolumn,
-        type: meta_data.type,
-        element: schemaPath[schemaPath.length - 1].element,
-        schemaPath,
-        codec: meta_data.codec,
-        compressors: options.compressors,
-        utf8: options.utf8,
-      }
-      /** @type {DecodedArray[] | undefined} */
-      let chunks = readColumn(reader, rowGroupSelect, columnDecoder, options.onPage)
-
-      // skip assembly if no onComplete or onChunk
-      if (!options.onComplete && !options.onChunk) return
-
-      // TODO: fast path for non-nested columns
-      // save column data for assembly
-      subcolumnData.set(subcolumn, chunks)
-      chunks = undefined
-
-      const subcolumns = subcolumnNames.get(columnName)
-      if (subcolumns?.every(name => subcolumnData.has(name))) {
-        // For every subcolumn, flatten and assemble the column
-        const flatData = new Map(subcolumns.map(name => [name, flatten(subcolumnData.get(name))]))
-        assembleNested(flatData, schemaPath[1])
-        const flatColumn = flatData.get(columnName)
-        if (!flatColumn) throw new Error(`parquet column data not assembled: ${columnName}`)
-        chunks = [flatColumn]
-        subcolumns.forEach(name => subcolumnData.delete(name))
-        subcolumnData.set(columnName, chunks)
-      }
-
-      // do not emit column data until structs are fully parsed
-      if (!chunks) return
-      // notify caller of column data
-      if (options.onChunk) {
-        for (const columnData of chunks) {
-          options.onChunk({
-            columnName,
-            columnData,
-            rowStart: groupStart,
-            rowEnd: groupStart + columnData.length,
-          })
+    asyncColumns.push({
+      pathInSchema: meta_data.path_in_schema,
+      data: buffer.then(arrayBuffer => {
+        const schemaPath = getSchemaPath(metadata.schema, meta_data.path_in_schema)
+        const reader = { view: new DataView(arrayBuffer), offset: 0 }
+        const subcolumn = meta_data.path_in_schema.join('.')
+        const columnDecoder = {
+          columnName: subcolumn,
+          type: meta_data.type,
+          element: schemaPath[schemaPath.length - 1].element,
+          schemaPath,
+          codec: meta_data.codec,
+          compressors,
+          utf8,
         }
-      }
-    }))
+        return readColumn(reader, groupPlan, columnDecoder, options.onPage)
+      }),
+    })
   }
-  await Promise.all(promises)
-  if (options.onComplete) {
-    const includedColumnNames = children
-      .map(child => child.element.name)
-      .filter(name => !columns || columns.includes(name))
-    const columnOrder = columns || includedColumnNames
-    const includedColumns = columnOrder
-      .map(name => includedColumnNames.includes(name) ? flatten(subcolumnData.get(name)) : undefined)
 
-    // transpose columns into rows
-    const groupData = new Array(selectEnd)
-    for (let row = selectStart; row < selectEnd; row++) {
-      if (options.rowFormat === 'object') {
-        // return each row as an object
-        /** @type {Record<string, any>} */
-        const rowData = {}
-        for (let i = 0; i < columnOrder.length; i++) {
-          rowData[columnOrder[i]] = includedColumns[i]?.[row]
-        }
-        groupData[row] = rowData
-      } else {
-        // return each row as an array
-        groupData[row] = includedColumns.map(column => column?.[row])
-      }
-    }
-    return groupData
-  }
-  return []
+  return { groupStart: groupPlan.groupStart, groupRows: groupPlan.groupRows, asyncColumns }
 }
 
 /**
- * Return a list of sub-columns needed to construct a top-level column.
- *
- * @import {DecodedArray, ParquetReadOptions, RowGroup, RowGroupSelect, SchemaTree} from '../src/types.d.ts'
- * @param {SchemaTree} schema
- * @param {string[]} output
- * @returns {string[]}
+ * @param {AsyncRowGroup} asyncGroup
+ * @param {number} selectStart
+ * @param {number} selectEnd
+ * @param {string[] | undefined} columns
+ * @param {'object' | 'array'} [rowFormat]
+ * @returns {Promise<Record<string, any>[]>} resolves to row data
  */
-function getSubcolumns(schema, output = []) {
-  if (schema.children.length) {
-    for (const child of schema.children) {
-      getSubcolumns(child, output)
+export async function asyncGroupToRows({ asyncColumns }, selectStart, selectEnd, columns, rowFormat) {
+  const groupData = new Array(selectEnd)
+
+  // columnData[i] for asyncColumns[i]
+  // TODO: do it without flatten
+  const columnDatas = await Promise.all(asyncColumns.map(({ data }) => data.then(flatten)))
+
+  // careful mapping of column order for rowFormat: array
+  const includedColumnNames = asyncColumns
+    .map(child => child.pathInSchema[0])
+    .filter(name => !columns || columns.includes(name))
+  const columnOrder = columns ?? includedColumnNames
+  const columnIndexes = columnOrder.map(name => asyncColumns.findIndex(column => column.pathInSchema[0] === name))
+
+  // transpose columns into rows
+  for (let row = selectStart; row < selectEnd; row++) {
+    if (rowFormat === 'object') {
+      // return each row as an object
+      /** @type {Record<string, any>} */
+      const rowData = {}
+      for (let i = 0; i < asyncColumns.length; i++) {
+        rowData[asyncColumns[i].pathInSchema[0]] = columnDatas[i][row]
+      }
+      groupData[row] = rowData
+    } else {
+      // return each row as an array
+      const rowData = new Array(asyncColumns.length)
+      for (let i = 0; i < columnOrder.length; i++) {
+        if (columnIndexes[i] >= 0) {
+          rowData[i] = columnDatas[columnIndexes[i]][row]
+        }
+      }
+      groupData[row] = rowData
     }
-  } else {
-    output.push(schema.path.join('.'))
   }
-  return output
+  return groupData
+}
+
+/**
+ * Assemble physical columns into top-level columns asynchronously.
+ *
+ * @param {AsyncRowGroup} asyncRowGroup
+ * @param {SchemaTree} schemaTree
+ * @returns {AsyncRowGroup}
+ */
+export function assembleAsync(asyncRowGroup, schemaTree) {
+  const { asyncColumns } = asyncRowGroup
+  /** @type {AsyncColumn[]} */
+  const assembled = []
+  for (const child of schemaTree.children) {
+    if (child.children.length) {
+      const childColumns = asyncColumns.filter(column => column.pathInSchema[0] === child.element.name)
+      if (!childColumns.length) continue
+
+      // wait for all child columns to be read
+      /** @type {Map<string, DecodedArray>} */
+      const flatData = new Map()
+      const data = Promise.all(childColumns.map(column => {
+        return column.data.then(columnData => {
+          flatData.set(column.pathInSchema.join('.'), flatten(columnData))
+        })
+      })).then(() => {
+        // assemble the column
+        assembleNested(flatData, child)
+        const flatColumn = flatData.get(child.path.join('.'))
+        if (!flatColumn) throw new Error('parquet column data not assembled')
+        return [flatColumn]
+      })
+
+      assembled.push({ pathInSchema: child.path, data })
+    } else {
+      // leaf node, return the column
+      const asyncColumn = asyncColumns.find(column => column.pathInSchema[0] === child.element.name)
+      if (asyncColumn) {
+        assembled.push(asyncColumn)
+      }
+    }
+  }
+  return { ...asyncRowGroup, asyncColumns: assembled }
 }

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -419,3 +419,13 @@ export interface RowGroupSelect {
   selectEnd: number // row index in the group to stop reading
   groupRows: number
 }
+
+export interface AsyncColumn {
+  pathInSchema: string[]
+  data: Promise<DecodedArray[]>
+}
+export interface AsyncRowGroup {
+  groupStart: number
+  groupRows: number
+  asyncColumns: AsyncColumn[]
+}


### PR DESCRIPTION
This PR introduces a new abstraction for reading parquet data in a more efficient and flexible way. The `AsyncRowGroup` interface returns a map of future data to be returned, allowing for better performance and easier integration with various use cases.

```typescript
export interface AsyncRowGroup {
  groupStart: number
  groupRows: number
  asyncColumns: AsyncColumn[]
}
export interface AsyncColumn {
  pathInSchema: string[]
  data: Promise<DecodedArray[]>
}
```

`AsyncRowGroup` is made up of `AsyncColumn`s. Collectively this gives a map of the incoming data. This abstraction is designed to be a direct representation of how **parquet** data is fetched. The goal is to make it easy to build on top of this abstraction, and not get in the way of maximum performance. Data is returned as lists-of-lists to avoid `concat` (consumers can `flatten` if they want).

Want to built `onComplete` from `AsyncRowGroup`? It's in the PR.

Want to build `onChunk` from `AsyncRowGroup`? It's in the PR.

Want to build `getColumn`? The current implementation in cli requires complex caching and re-assembly and sorting (see [getParquetColumn](https://github.com/hyparam/hyperparam-cli/blob/master/src/lib/getParquetColumn.ts) by @severo). No more re-assembly from `onChunk` with `AsyncRowGroup` (it's in the PR):

```typescript
async function parquetReadColumn({ file, columnName }): Promise<DecodedArray> {
  const asyncGroups = parquetReadAsync({ file, metadata, columns: [columnName] })
  const columnData = []
  for (const rg of asyncGroups) {
    columnData.push(await rg.asyncColumns[0].data)
  }
  return flatten(flatten(columnData))
}
```

Want to build an `AsyncGenerator` that yields row objects, emitted in row groups:

```typescript
async function* parquetReadGenerator({ file, columns }): AsyncGenerator<Record<string, any>[]> {
  const asyncGroups = parquetReadAsync({ file, metadata, columns })
  for (const rg of asyncGroups) {
    yield await asyncGroupToRows(rg, 0, rg.groupRows, columns)
  }
}
```

Benchmarks show improvement in `getColumn` type queries and ALSO on sorting queries where `parquetQuery` is called with `orderBy`. This is because it's not having to transpose an entire column of rows. This can save 3+ seconds on sorting tpch.

I'm excited for this one!