### PR TITLE
Fix filter on unselected column

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -39,6 +39,8 @@ export default [
       'jsdoc/require-returns': 'error',
       'jsdoc/require-returns-type': 'error',
       'jsdoc/sort-tags': 'error',
+      'key-spacing': 'error',
+      'keyword-spacing': 'error',
       'no-constant-condition': 'off',
       'no-extra-parens': 'error',
       'no-multi-spaces': 'error',

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -36,21 +36,23 @@ export interface ParquetReadOptions {
 /**
  * Parquet query options for filtering data
  */
-export interface ParquetQueryFilter {
-  [key: string]: ParquetQueryValue | ParquetQueryOperator | ParquetQueryFilter[] | undefined
-  $and?: ParquetQueryFilter[]
-  $or?: ParquetQueryFilter[]
-  $not?: ParquetQueryFilter
-}
+export type ParquetQueryFilter =
+  | ParquetQueryColumnsFilter
+  | { $and: ParquetQueryFilter[] }
+  | { $or: ParquetQueryFilter[] }
+  | { $nor: ParquetQueryFilter[] }
+type ParquetQueryColumnsFilter = { [key: string]: ParquetQueryOperator }
 export type ParquetQueryValue = string | number | boolean | object | null | undefined
 export type ParquetQueryOperator = {
   $gt?: ParquetQueryValue
   $gte?: ParquetQueryValue
   $lt?: ParquetQueryValue
   $lte?: ParquetQueryValue
+  $eq?: ParquetQueryValue
   $ne?: ParquetQueryValue
   $in?: ParquetQueryValue[]
   $nin?: ParquetQueryValue[]
+  $not?: ParquetQueryOperator
 }
 
 /**

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -54,15 +54,9 @@ describe('parquetQuery', () => {
     ])
   })
 
-  it('throws for invalid orderBy column', async () => {
-    const file = await asyncBufferFromFile('test/files/datapage_v2.snappy.parquet')
-    const futureRows = parquetQuery({ file, orderBy: 'nonexistent' })
-    await expect(futureRows).rejects.toThrow('parquet columns not found: nonexistent')
-  })
-
   it('reads data with filter', async () => {
     const file = await asyncBufferFromFile('test/files/datapage_v2.snappy.parquet')
-    const rows = await parquetQuery({ file, filter: { c: 2 } })
+    const rows = await parquetQuery({ file, filter: { c: { $eq: 2 } } })
     expect(rows).toEqual([
       { a: 'abc', b: 1, c: 2, d: true, e: [ 1, 2, 3 ] },
       { a: 'abc', b: 5, c: 2, d: true, e: [ 1, 2 ] },
@@ -71,13 +65,13 @@ describe('parquetQuery', () => {
 
   it('reads data with filter and rowStart/rowEnd', async () => {
     const file = await asyncBufferFromFile('test/files/datapage_v2.snappy.parquet')
-    const rows = await parquetQuery({ file, filter: { c: 2 }, rowStart: 1, rowEnd: 5 })
+    const rows = await parquetQuery({ file, filter: { c: { $eq: 2 } }, rowStart: 1, rowEnd: 5 })
     expect(rows).toEqual([ { a: 'abc', b: 5, c: 2, d: true, e: [ 1, 2 ] } ])
   })
 
   it('reads data with filter and orderBy', async () => {
     const file = await asyncBufferFromFile('test/files/datapage_v2.snappy.parquet')
-    const rows = await parquetQuery({ file, filter: { c: 2 }, orderBy: 'b' })
+    const rows = await parquetQuery({ file, filter: { c: { $eq: 2 } }, orderBy: 'b' })
     expect(rows).toEqual([
       { a: 'abc', b: 1, c: 2, d: true, e: [ 1, 2, 3 ] },
       { a: 'abc', b: 5, c: 2, d: true, e: [ 1, 2 ] },
@@ -86,13 +80,23 @@ describe('parquetQuery', () => {
 
   it('reads data with filter, orderBy, and rowStart/rowEnd', async () => {
     const file = await asyncBufferFromFile('test/files/datapage_v2.snappy.parquet')
-    const rows = await parquetQuery({ file, filter: { c: 2 }, orderBy: 'b', rowStart: 1, rowEnd: 2 })
+    const rows = await parquetQuery({ file, filter: { c: { $eq: 2 } }, orderBy: 'b', rowStart: 1, rowEnd: 2 })
     expect(rows).toEqual([ { a: 'abc', b: 5, c: 2, d: true, e: [ 1, 2 ] } ])
+  })
+
+  it('reads data with multiple column filter operators', async () => {
+    const file = await asyncBufferFromFile('test/files/datapage_v2.snappy.parquet')
+    const rows = await parquetQuery({ file, filter: { c: { $gt: 1, $lt: 4 }, d: { $eq: true } } })
+    expect(rows).toEqual([
+      { a: 'abc', b: 1, c: 2, d: true, e: [1, 2, 3] },
+      { a: 'abc', b: 2, c: 3, d: true },
+      { a: 'abc', b: 5, c: 2, d: true, e: [1, 2] },
+    ])
   })
 
   it('reads data with $and filter', async () => {
     const file = await asyncBufferFromFile('test/files/datapage_v2.snappy.parquet')
-    const rows = await parquetQuery({ file, filter: { $and: [{ c: 2 }, { e: [1, 2, 3] }] } })
+    const rows = await parquetQuery({ file, filter: { $and: [{ c: { $eq: 2 } }, { e: { $eq: [1, 2, 3] } }] } })
     expect(rows).toEqual([
       { a: 'abc', b: 1, c: 2, d: true, e: [1, 2, 3] },
     ])
@@ -100,7 +104,7 @@ describe('parquetQuery', () => {
 
   it('reads data with $or filter', async () => {
     const file = await asyncBufferFromFile('test/files/datapage_v2.snappy.parquet')
-    const rows = await parquetQuery({ file, filter: { $or: [{ c: 2 }, { d: false }] } })
+    const rows = await parquetQuery({ file, filter: { $or: [{ c: { $eq: 2 } }, { d: { $eq: false } }] } })
     expect(rows).toEqual([
       { a: 'abc', b: 1, c: 2, d: true, e: [1, 2, 3] },
       { a: null, b: 4, c: 5, d: false, e: [1, 2, 3] },
@@ -108,19 +112,17 @@ describe('parquetQuery', () => {
     ])
   })
 
-  it('reads data with $not filter', async () => {
+  it('reads data with $nor filter', async () => {
     const file = await asyncBufferFromFile('test/files/datapage_v2.snappy.parquet')
-    const rows = await parquetQuery({ file, filter: { $not: { c: 2 } } })
+    const rows = await parquetQuery({ file, filter: { $nor: [{ c: { $eq: 2 } }, { d: { $eq: true } }] } })
     expect(rows).toEqual([
-      { a: 'abc', b: 2, c: 3, d: true },
-      { a: 'abc', b: 3, c: 4, d: true },
       { a: null, b: 4, c: 5, d: false, e: [1, 2, 3] },
     ])
   })
 
-  it('reads data with $not value filter', async () => {
+  it('reads data with $not filter', async () => {
     const file = await asyncBufferFromFile('test/files/datapage_v2.snappy.parquet')
-    const rows = await parquetQuery({ file, filter: { c: { $not: 2 } } })
+    const rows = await parquetQuery({ file, filter: { c: { $not: { $eq: 2 } } } })
     expect(rows).toEqual([
       { a: 'abc', b: 2, c: 3, d: true },
       { a: 'abc', b: 3, c: 4, d: true },
@@ -199,7 +201,7 @@ describe('parquetQuery', () => {
 
   it('reads data efficiently with filter', async () => {
     const file = countingBuffer(await asyncBufferFromFile('test/files/page_indexed.parquet'))
-    const rows = await parquetQuery({ file, filter: { quality: 'good' }, rowStart: 1, rowEnd: 5 })
+    const rows = await parquetQuery({ file, filter: { quality: { $eq: 'good' } }, rowStart: 1, rowEnd: 5 } )
     expect(rows).toEqual([
       { row: 10n, quality: 'good' },
       { row: 29n, quality: 'good' },
@@ -209,5 +211,26 @@ describe('parquetQuery', () => {
     // if we weren't streaming row groups, this would be 3:
     expect(file.fetches).toBe(2) // 1 metadata, 1 row group
     expect(file.bytes).toBe(5261)
+  })
+
+  it('filter on columns that are not selected', async () => {
+    const file = await asyncBufferFromFile('test/files/datapage_v2.snappy.parquet')
+    const rows = await parquetQuery({ file, columns: ['a', 'b'], filter: { c: { $eq: 2 } } })
+    expect(rows).toEqual([
+      { a: 'abc', b: 1 },
+      { a: 'abc', b: 5 },
+    ])
+  })
+
+  it('throws on non-existent column in filter', async () => {
+    const file = await asyncBufferFromFile('test/files/datapage_v2.snappy.parquet')
+    await expect(parquetQuery({ file, filter: { nonExistent: { $eq: 1 } } }))
+      .rejects.toThrow('parquet filter columns not found: nonExistent')
+  })
+
+  it('throws on non-existent column in orderBy', async () => {
+    const file = await asyncBufferFromFile('test/files/datapage_v2.snappy.parquet')
+    await expect(parquetQuery({ file, orderBy: 'nonExistent' }))
+      .rejects.toThrow('parquet orderBy column not found: nonExistent')
   })
 })


### PR DESCRIPTION
There was previously a bug where if you tried to filter on a column that was not selected in the `columns: [...]` param, the filter would fail. This PR:

 - Find the "relevant" columns to fetch including requested, orderby, and filtered columns
 - Changes the `ParquetQueryFilter` type to actually match the mongo filter syntax.
 - $not cannot be at the top level
 - Added $nor filter for top-level not semantics
 - Added $eq operator
 - REMOVE IMPLICIT $eq. Things like `{ c: 3 }` must now be `{ c: { $eq: 3 } }`. This was always a nightmare to support implicit eq values because... what do you do when the value itself is an object? Requiring $eq makes this unambiguous.

BREAKING CHANGE TO `parquetQuery` with `filter`.
