### PR TITLE
Predicate Pushdown

### DIFF
--- a/src/column.js
+++ b/src/column.js
@@ -248,7 +248,7 @@ export function decodeDataPage(buffer, columnDecoder, dictionary, rowLimit) {
   const values = readPage(reader, header, columnDecoder, dictionary, undefined, 0)
 
   // If we have a row limit and the page has more rows, truncate
-  if (rowLimit !== undefined && pageRows > rowLimit) {
+  if (rowLimit !== undefined && pageRows !== undefined && pageRows > rowLimit) {
     return values.slice(0, rowLimit)
   }
 

--- a/src/column.js
+++ b/src/column.js
@@ -151,7 +151,7 @@ export function readPage(reader, header, columnDecoder, dictionary, previousChun
  * @param {DataReader} reader
  * @returns {PageHeader}
  */
-function parquetHeader(reader) {
+export function parquetHeader(reader) {
   const header = deserializeTCompactProtocol(reader)
 
   // Parse parquet header from thrift data
@@ -200,4 +200,57 @@ function parquetHeader(reader) {
     dictionary_page_header,
     data_page_header_v2,
   }
+}
+
+/**
+ * Decode a dictionary page from a pre-fetched buffer.
+ *
+ * @param {ArrayBuffer} buffer - buffer containing the dictionary page
+ * @param {ColumnDecoder} columnDecoder - column decoder parameters
+ * @returns {DecodedArray} decoded dictionary values
+ */
+export function decodeDictionaryPage(buffer, columnDecoder) {
+  const reader = { view: new DataView(buffer), offset: 0 }
+  const header = parquetHeader(reader)
+
+  if (header.type !== 'DICTIONARY_PAGE') {
+    throw new Error(`Expected DICTIONARY_PAGE but got ${header.type}`)
+  }
+
+  const dictionary = readPage(reader, header, columnDecoder, undefined, undefined, 0)
+  const converted = convert(dictionary, columnDecoder)
+
+  return converted
+}
+
+/**
+ * Decode a data page from a pre-fetched buffer.
+ *
+ * @param {ArrayBuffer} buffer - buffer containing the data page
+ * @param {ColumnDecoder} columnDecoder - column decoder parameters
+ * @param {DecodedArray} [dictionary] - optional dictionary for dictionary encoding
+ * @param {number} [rowLimit] - maximum number of rows to read
+ * @returns {DecodedArray} decoded values
+ */
+export function decodeDataPage(buffer, columnDecoder, dictionary, rowLimit) {
+  const reader = { view: new DataView(buffer), offset: 0 }
+  const header = parquetHeader(reader)
+
+  if (header.type !== 'DATA_PAGE' && header.type !== 'DATA_PAGE_V2') {
+    throw new Error(`Expected DATA_PAGE or DATA_PAGE_V2 but got ${header.type}`)
+  }
+
+  // For data pages, we may need to limit the number of values read
+  const pageRows = header.type === 'DATA_PAGE'
+    ? header.data_page_header?.num_values
+    : header.data_page_header_v2?.num_rows
+
+  const values = readPage(reader, header, columnDecoder, dictionary, undefined, 0)
+
+  // If we have a row limit and the page has more rows, truncate
+  if (rowLimit !== undefined && pageRows > rowLimit) {
+    return values.slice(0, rowLimit)
+  }
+
+  return values
 }

--- a/src/plan.js
+++ b/src/plan.js
@@ -109,8 +109,8 @@ export function prefetchAsyncBuffer(file, { fetches }) {
 }
 
 /**
- * Calculate the total byte range of a row group including indices.
- * Includes column data and any page indices for complete row group reads.
+ * Calculate the total byte range of a row group including indexes.
+ * Includes column data and any page indexes for complete row group reads.
  *
  * @param {RowGroup} rowGroup - row group metadata
  * @returns {{start: number, end: number, size: number}} byte range and size

--- a/src/plan.js
+++ b/src/plan.js
@@ -1,10 +1,10 @@
 import { concat } from './utils.js'
 
-// Combine column chunks into a single byte range if less than 32mb
+// Threshold for combining adjacent column chunks into a single read
 const columnChunkAggregation = 1 << 25 // 32mb
 
 /**
- * @import {AsyncBuffer, ByteRange, ColumnMetaData, GroupPlan, ParquetReadOptions, QueryPlan} from '../src/types.js'
+ * @import {AsyncBuffer, ByteRange, RowGroup, ColumnMetaData, GroupPlan, ParquetReadOptions, QueryPlan} from '../src/types.js'
  */
 /**
  * Plan which byte ranges to read to satisfy a read request.
@@ -105,5 +105,160 @@ export function prefetchAsyncBuffer(file, { fetches }) {
         return promises[index]
       }
     },
+  }
+}
+
+/**
+ * Calculate the total byte range of a row group including indices.
+ * Includes column data and any page indices for complete row group reads.
+ *
+ * @param {RowGroup} rowGroup - row group metadata
+ * @returns {{start: number, end: number, size: number}} byte range and size
+ */
+export function getRowGroupFullRange(rowGroup) {
+  let start = Infinity
+  let end = 0
+
+  for (const col of rowGroup.columns) {
+    if (col.meta_data) {
+      // Column data range
+      const colStart = Number(col.meta_data.dictionary_page_offset || col.meta_data.data_page_offset)
+      const colEnd = colStart + Number(col.meta_data.total_compressed_size)
+      start = Math.min(start, colStart)
+      end = Math.max(end, colEnd)
+
+      // Include column index if present
+      if (col.column_index_offset) {
+        const indexEnd = Number(col.column_index_offset) + Number(col.column_index_length)
+        end = Math.max(end, indexEnd)
+      }
+
+      // Include offset index if present
+      if (col.offset_index_offset) {
+        const offsetEnd = Number(col.offset_index_offset) + Number(col.offset_index_length)
+        end = Math.max(end, offsetEnd)
+      }
+    }
+  }
+
+  return { start, end, size: end - start }
+}
+
+/**
+ * Create column name to index mapping for a row group.
+ * Enables lookup by name since row groups store columns by index.
+ *
+ * @param {RowGroup} rowGroup - row group metadata
+ * @returns {Map<string, number>} map from column name to index
+ */
+export function createColumnIndexMap(rowGroup) {
+  const map = new Map()
+  rowGroup.columns.forEach((column, index) => {
+    if (column.meta_data?.path_in_schema?.length > 0) {
+      map.set(column.meta_data.path_in_schema[0], index)
+    }
+  })
+  return map
+}
+
+/**
+ * Extract column names from filter.
+ * Needed to read filter columns that may not be in the output.
+ *
+ * @param {object} filter - MongoDB-style filter object
+ * @returns {string[]} array of column names referenced in filter
+ */
+export function extractFilterColumns(filter) {
+  const columns = new Set()
+
+  function extract(f) {
+    if (f.$and || f.$or || f.$nor) {
+      (f.$and || f.$or || f.$nor).forEach(extract)
+    } else if (f.$not) {
+      extract(f.$not)
+    } else {
+      Object.keys(f).forEach((k) => {
+        if (!k.startsWith('$')) columns.add(k)
+      })
+    }
+  }
+
+  extract(filter)
+  return [...columns]
+}
+
+/**
+ * Create predicates from MongoDB-style filter.
+ * Converts filters to functions that test against min/max statistics.
+ *
+ * @param {object} filter - MongoDB-style filter object
+ * @returns {Map<string, (min: any, max: any) => boolean>} map from column to predicate function
+ */
+export function createPredicates(filter) {
+  const predicates = new Map()
+
+  function processFilter(f) {
+    if (f.$and) {
+      f.$and.forEach(processFilter)
+    } else if (f.$or) {
+      // OR predicates across different columns can't use statistics effectively
+    } else {
+      // Process column-level conditions
+      for (const [col, cond] of Object.entries(f)) {
+        if (!col.startsWith('$')) {
+          const pred = createRangePredicate(cond)
+          if (pred) {
+            predicates.set(col, pred)
+          }
+        }
+      }
+    }
+  }
+
+  processFilter(filter)
+  return predicates
+}
+
+/**
+ * Create range predicate from condition.
+ * Returns a function that tests if a [min,max] range could contain matching values.
+ *
+ * @param {any} condition - filter condition (value or operators object)
+ * @returns {((min: any, max: any) => boolean)|null} predicate function or null
+ */
+export function createRangePredicate(condition) {
+  // Handle direct value comparison
+  if (typeof condition !== 'object' || condition === null) {
+    return (min, max) => min <= condition && condition <= max
+  }
+
+  const { $eq, $gt, $gte, $lt, $lte, $in } = condition
+
+  // Test if statistics range could contain values matching the condition
+  return (min, max) => {
+    if ($eq !== undefined) {
+      return min <= $eq && $eq <= max
+    }
+
+    if ($in && Array.isArray($in)) {
+      return $in.some((v) => min <= v && v <= max)
+    }
+
+    let possible = true
+
+    if ($gt !== undefined) {
+      possible = possible && max > $gt
+    }
+    if ($gte !== undefined) {
+      possible = possible && max >= $gte
+    }
+    if ($lt !== undefined) {
+      possible = possible && min < $lt
+    }
+    if ($lte !== undefined) {
+      possible = possible && min <= $lte
+    }
+
+    return possible
   }
 }

--- a/src/plan.js
+++ b/src/plan.js
@@ -154,7 +154,7 @@ export function getRowGroupFullRange(rowGroup) {
 export function createColumnIndexMap(rowGroup) {
   const map = new Map()
   rowGroup.columns.forEach((column, index) => {
-    if (column.meta_data?.path_in_schema?.length > 0) {
+    if (column.meta_data?.path_in_schema?.length && column.meta_data.path_in_schema.length > 0) {
       map.set(column.meta_data.path_in_schema[0], index)
     }
   })
@@ -171,6 +171,9 @@ export function createColumnIndexMap(rowGroup) {
 export function extractFilterColumns(filter) {
   const columns = new Set()
 
+  /**
+   * @param {any} f
+   */
   function extract(f) {
     if (f.$and || f.$or || f.$nor) {
       (f.$and || f.$or || f.$nor).forEach(extract)
@@ -197,6 +200,9 @@ export function extractFilterColumns(filter) {
 export function createPredicates(filter) {
   const predicates = new Map()
 
+  /**
+   * @param {any} f
+   */
   function processFilter(f) {
     if (f.$and) {
       f.$and.forEach(processFilter)

--- a/src/query.js
+++ b/src/query.js
@@ -1,8 +1,3 @@
-/**
- * Query implementation with predicate pushdown.
- * Uses Parquet statistics to skip data that doesn't match filters.
- */
-
 import { readColumnIndex, readOffsetIndex } from './indexes.js'
 import { parquetMetadataAsync, parquetSchema } from './metadata.js'
 import { getSchemaPath } from './schema.js'
@@ -10,58 +5,15 @@ import { readColumn } from './column.js'
 import { parquetReadObjects } from './index.js'
 import { DEFAULT_PARSERS } from './convert.js'
 import { concat, equals } from './utils.js'
+import { createColumnIndexMap, createPredicates, extractFilterColumns, getRowGroupFullRange } from './plan.js'
 
 /**
- * Batch read multiple byte ranges from the file in a single operation.
- * This reduces network round trips when reading from remote storage
- * and allows the underlying implementation to optimize concurrent reads.
- * @param {AsyncBuffer} file - File buffer
- * @param {Array<[number, number] | null>} ranges - Array of byte ranges
- * @returns {Promise<ArrayBuffer[]>} Array of buffers
+ * @import {AsyncBuffer, FileMetaData, ColumnChunk, SchemaElement, ColumnIndex, OffsetIndex, CompressionCodec, Compressors, ParquetParsers, RowGroup, DecodedArray} from './types.js'
  */
-function sliceAll(file, ranges) {
-  return (
-    file.sliceAll?.(ranges) ??
-    Promise.all(ranges.map((range) => range ? file.slice(range[0], range[1]) : Promise.resolve(new ArrayBuffer(0))))
-  )
-}
 
 /**
- * Calculate the total byte range of a row group including indices
- * @param {object} rowGroup - Row group metadata
- * @returns {{start: number, end: number, size: number}} - Byte range and size
- */
-function getRowGroupFullRange(rowGroup) {
-  let start = Infinity
-  let end = 0
-
-  for (const col of rowGroup.columns) {
-    if (col.meta_data) {
-      // Column data range
-      const colStart = Number(col.meta_data.dictionary_page_offset || col.meta_data.data_page_offset)
-      const colEnd = colStart + Number(col.meta_data.total_compressed_size)
-      start = Math.min(start, colStart)
-      end = Math.max(end, colEnd)
-
-      // Include column index if present
-      if (col.column_index_offset) {
-        const indexEnd = Number(col.column_index_offset) + Number(col.column_index_length)
-        end = Math.max(end, indexEnd)
-      }
-
-      // Include offset index if present
-      if (col.offset_index_offset) {
-        const offsetEnd = Number(col.offset_index_offset) + Number(col.offset_index_length)
-        end = Math.max(end, offsetEnd)
-      }
-    }
-  }
-
-  return { start, end, size: end - start }
-}
-
-/**
- * Query parquet file with predicate pushdown optimization
+ * Query parquet file with predicate pushdown.
+ * Uses Parquet statistics to skip data that doesn't match filters.
  * @param {object} options - Query options
  * @param {AsyncBuffer} options.file - Parquet file buffer
  * @param {FileMetaData} [options.metadata] - Parquet metadata (will be loaded if not provided)
@@ -94,14 +46,13 @@ export async function parquetQuery(options) {
   // Need both output columns and filter columns for evaluation
   const filterColumns = filter ? extractFilterColumns(filter) : []
   const outputColumns = columns || allColumns
-  const requiredColumns = new Set([...outputColumns, ...filterColumns, orderBy].filter(Boolean))
+  const requiredColumns = [...new Set([...outputColumns, ...filterColumns, orderBy].filter(Boolean))]
 
   // Convert filter to predicates that can test min/max statistics
   const predicates = filter ? createPredicates(filter) : new Map()
 
   // Validate columns exist
   if (filter) {
-    const filterColumns = extractFilterColumns(filter)
     const missingColumns = filterColumns.filter((col) => !allColumns.includes(col))
     if (missingColumns.length) {
       throw new Error(`parquet filter columns not found: ${missingColumns.join(', ')}`)
@@ -111,140 +62,7 @@ export async function parquetQuery(options) {
     throw new Error(`parquet orderBy column not found: ${orderBy}`)
   }
 
-  // Can stream results when filtering without sorting and we know the limit
-  if (filter && !orderBy && limit !== undefined && offset + limit < Number(metadata.num_rows)) {
-    const filteredRows = []
-    let groupStart = 0
-
-    for (let rgIndex = 0; rgIndex < metadata.row_groups.length; rgIndex++) {
-      const rowGroup = metadata.row_groups[rgIndex]
-      const groupRows = Number(rowGroup.num_rows)
-
-      // Row group statistics let us skip entire groups without reading any data
-      if (!canRowGroupMatch(rowGroup, predicates)) {
-        groupStart += groupRows
-        continue
-      }
-
-      // Small row groups are more efficient to read in one shot than multiple reads
-      const { start: rgStart, end: rgEnd, size: rgSize } = getRowGroupFullRange(rowGroup)
-      const ROW_GROUP_SIZE_THRESHOLD = 4 * 1024 * 1024 // 4MB
-
-      let groupData
-
-      if (rgSize < ROW_GROUP_SIZE_THRESHOLD) {
-        // Read entire row group in one shot
-        const rgBuffer = await file.slice(rgStart, rgEnd)
-
-        // All subsequent reads will be served from this prefetched buffer
-        const bufferedFile = {
-          byteLength: file.byteLength,
-          slice(start, end) {
-            if (start >= rgStart && end <= rgEnd) {
-              return Promise.resolve(rgBuffer.slice(start - rgStart, end - rgStart))
-            }
-            return file.slice(start, end)
-          },
-          sliceAll(ranges) {
-            // All ranges in buffer means we can serve from memory
-            const allInBuffer = ranges.every((range) => !range || range[0] >= rgStart && range[1] <= rgEnd)
-
-            if (allInBuffer) {
-              return Promise.resolve(
-                ranges.map((range) => range ? rgBuffer.slice(range[0] - rgStart, range[1] - rgStart) : new ArrayBuffer(0))
-              )
-            }
-
-            // Otherwise delegate to original file
-            return sliceAll(file, ranges)
-          },
-        }
-
-        // Now read with the buffered file
-        const hasIndices = rowGroup.columns.some((col) => col.column_index_offset)
-
-        if (hasIndices && predicates.size > 0) {
-          groupData = await readRowGroupWithPageFilter(bufferedFile, metadata, rgIndex, predicates, [...requiredColumns], options)
-        } else {
-          groupData = await parquetReadObjects({
-            ...options,
-            file: bufferedFile,
-            metadata,
-            columns: [...requiredColumns],
-            rowStart: groupStart,
-            rowEnd: groupStart + groupRows,
-          })
-        }
-      } else {
-        // Large row groups read normally to avoid memory bloat
-        const hasIndices = rowGroup.columns.some((col) => col.column_index_offset)
-
-        if (hasIndices && predicates.size > 0) {
-          groupData = await readRowGroupWithPageFilter(file, metadata, rgIndex, predicates, [...requiredColumns], options)
-        } else {
-          groupData = await parquetReadObjects({
-            ...options,
-            file,
-            metadata,
-            columns: [...requiredColumns],
-            rowStart: groupStart,
-            rowEnd: groupStart + groupRows,
-          })
-        }
-      }
-
-      // Apply filter to each row as we read it
-      for (const row of groupData) {
-        if (matchesFilter(row, filter)) {
-          filteredRows.push(row)
-          // Early exit if we have enough rows
-          if (filteredRows.length >= offset + limit) {
-            const sliced = filteredRows.slice(offset, offset + limit)
-            return columns ? sliced.map((row) => projectRow(row, columns)) : sliced
-          }
-        }
-      }
-
-      groupStart += groupRows
-    }
-
-    // May have fewer rows than limit if we ran out of data
-    const sliced = filteredRows.slice(offset, offset + limit)
-    return columns ? sliced.map((row) => projectRow(row, columns)) : sliced
-  }
-
-  // Can't stream when we need to sort or don't know how many rows we need
-  const readOptions = filter || orderBy ? { ...options, rowStart: undefined, rowEnd: undefined } : options
-  const rows = await readWithPushdown(file, metadata, predicates, [...requiredColumns], readOptions)
-
-  // Need original positions to maintain stable sort for equal values
-  if (orderBy && !filter) {
-    rows.forEach((row, idx) => {
-      row.__index__ = idx
-    })
-  }
-
-  const filtered = filter ? rows.filter((row) => matchesFilter(row, filter)) : rows
-
-  // Order matters: filter first (reduce data), then sort, then slice, finally project
-  const sorted = orderBy ? sortRows(filtered, orderBy, desc) : filtered
-
-  // Slicing already done during read unless we filtered or sorted
-  const sliced = filter || orderBy ? sorted.slice(offset, limit ? offset + limit : undefined) : sorted
-
-  return columns ? sliced.map((row) => projectRow(row, columns)) : sliced
-}
-
-/**
- * Read data with predicate pushdown
- * @param {AsyncBuffer} file
- * @param {FileMetaData} metadata
- * @param {Map<string, Function>} predicates
- * @param {string[]} columns
- * @param {object} options
- * @returns {Promise<object[]>}
- */
-async function readWithPushdown(file, metadata, predicates, columns, options) {
+  // Main processing loop
   const rows = []
   let groupStart = 0
 
@@ -258,29 +76,137 @@ async function readWithPushdown(file, metadata, predicates, columns, options) {
       continue
     }
 
-    // Page indices provide finer-grained statistics than row groups
-    const hasIndices = rowGroup.columns.some((col) => col.column_index_offset)
+    // Apply 4MB optimization
+    const { size } = getRowGroupFullRange(rowGroup)
+    const useSmallGroupOptimization = size < 4 * 1024 * 1024
 
-    if (hasIndices && predicates.size > 0) {
-      // Use page-level filtering
-      const groupData = await readRowGroupWithPageFilter(file, metadata, rgIndex, predicates, columns, options)
-      rows.push(...groupData)
+    let groupData
+    if (useSmallGroupOptimization) {
+      groupData = await readSmallRowGroup(file, metadata, rgIndex, predicates, requiredColumns, options, groupStart)
     } else {
-      // No indices available, read entire row group
-      const groupData = await readRowGroup(file, metadata, rgIndex, columns, { ...options, columns }, groupStart)
-      rows.push(...groupData)
+      groupData = await readLargeRowGroup(file, metadata, rgIndex, predicates, requiredColumns, options, groupStart)
+    }
+
+    // Apply filter if needed
+    if (filter) {
+      groupData = groupData.filter((row) => matchesFilter(row, filter))
+    }
+
+    rows.push(...groupData)
+
+    // Early exit for limited queries without sorting
+    if (!orderBy && limit !== undefined && rows.length >= offset + limit) {
+      const sliced = rows.slice(offset, offset + limit)
+      return columns ? sliced.map((row) => projectRow(row, columns)) : sliced
     }
 
     groupStart += groupRows
   }
 
-  return rows
+  // Handle sorting
+  if (orderBy) {
+    if (!filter) {
+      // Add stable sort indices
+      rows.forEach((row, idx) => {
+        row.__index__ = idx
+      })
+    }
+    sortRows(rows, orderBy, desc)
+  }
+
+  // Final slice and projection
+  const sliced = filter || orderBy ? rows.slice(offset, limit ? offset + limit : undefined) : rows
+  return columns ? sliced.map((row) => projectRow(row, columns)) : sliced
+}
+
+/**
+ * Read small row group with buffering optimization
+ * @param {AsyncBuffer} file
+ * @param {FileMetaData} metadata
+ * @param {number} rgIndex
+ * @param {Map<string, (min: any, max: any) => boolean>} predicates
+ * @param {string[]} columns
+ * @param {object} options
+ * @param {number} groupStart
+ * @returns {Promise<object[]>}
+ */
+export async function readSmallRowGroup(file, metadata, rgIndex, predicates, columns, options, groupStart) {
+  const rowGroup = metadata.row_groups[rgIndex]
+  const { start, end } = getRowGroupFullRange(rowGroup)
+
+  // Read entire row group at once
+  const rgBuffer = await file.slice(start, end)
+
+  // Create buffered file
+  const bufferedFile = {
+    byteLength: file.byteLength,
+    slice(sliceStart, sliceEnd) {
+      if (sliceStart >= start && sliceEnd <= end) {
+        return Promise.resolve(rgBuffer.slice(sliceStart - start, sliceEnd - start))
+      }
+      return file.slice(sliceStart, sliceEnd)
+    },
+    sliceAll(ranges) {
+      const allInBuffer = ranges.every((range) => !range || range[0] >= start && range[1] <= end)
+      if (allInBuffer) {
+        return Promise.resolve(
+          ranges.map((range) => range ? rgBuffer.slice(range[0] - start, range[1] - start) : new ArrayBuffer(0))
+        )
+      }
+      return sliceAll(file, ranges)
+    },
+  }
+
+  // Use page filtering if available
+  const hasIndices = rowGroup.columns.some((col) => col.column_index_offset)
+  if (hasIndices && predicates.size > 0) {
+    return readRowGroupWithPageFilter(bufferedFile, metadata, rgIndex, predicates, columns, options)
+  }
+
+  // Otherwise read normally
+  return parquetReadObjects({
+    ...options,
+    file: bufferedFile,
+    metadata,
+    columns,
+    rowStart: groupStart,
+    rowEnd: groupStart + Number(rowGroup.num_rows),
+  })
+}
+
+/**
+ * Read large row group without buffering
+ * @param {AsyncBuffer} file
+ * @param {FileMetaData} metadata
+ * @param {number} rgIndex
+ * @param {Map<string, (min: any, max: any) => boolean>} predicates
+ * @param {string[]} columns
+ * @param {object} options
+ * @param {number} groupStart
+ * @returns {Promise<object[]>}
+ */
+export async function readLargeRowGroup(file, metadata, rgIndex, predicates, columns, options, groupStart) {
+  const rowGroup = metadata.row_groups[rgIndex]
+  const hasIndices = rowGroup.columns.some((col) => col.column_index_offset)
+
+  if (hasIndices && predicates.size > 0) {
+    return readRowGroupWithPageFilter(file, metadata, rgIndex, predicates, columns, options)
+  }
+
+  return await parquetReadObjects({
+    ...options,
+    file,
+    metadata,
+    columns,
+    rowStart: groupStart,
+    rowEnd: groupStart + Number(rowGroup.num_rows),
+  })
 }
 
 /**
  * Check if row group can contain matching rows based on statistics
- * @param {object} rowGroup
- * @param {Map<string, Function>} predicates
+ * @param {RowGroup} rowGroup
+ * @param {Map<string, (min: any, max: any) => boolean>} predicates
  * @returns {boolean}
  */
 function canRowGroupMatch(rowGroup, predicates) {
@@ -295,7 +221,7 @@ function canRowGroupMatch(rowGroup, predicates) {
 
     if (stats?.min_value !== undefined && stats?.max_value !== undefined) {
       if (!predicate(stats.min_value, stats.max_value)) {
-        return false // This row group cannot contain matches
+        return false
       }
     }
   }
@@ -308,61 +234,23 @@ function canRowGroupMatch(rowGroup, predicates) {
  * @param {AsyncBuffer} file
  * @param {FileMetaData} metadata
  * @param {number} rgIndex
- * @param {Map<string, Function>} predicates
+ * @param {Map<string, (min: any, max: any) => boolean>} predicates
  * @param {string[]} columns
  * @param {object} options
  * @returns {Promise<object[]>}
  */
-async function readRowGroupWithPageFilter(file, metadata, rgIndex, predicates, columns, options) {
+export async function readRowGroupWithPageFilter(file, metadata, rgIndex, predicates, columns, options) {
   const rowGroup = metadata.row_groups[rgIndex]
   const columnIndexMap = createColumnIndexMap(rowGroup)
 
-  // Page statistics are more precise than row group statistics
-  const pageSelections = await selectPages(file, metadata, rowGroup, predicates, columnIndexMap)
+  // Find pages that might contain matching data
+  const selectedPages = await selectPages(file, metadata, rowGroup, predicates, columnIndexMap)
+  if (!selectedPages || selectedPages.size === 0) return []
 
-  // No matching pages means no matching rows
-  if (!pageSelections || pageSelections.size === 0) return []
-
-  // Read all indices together instead of one by one
-  const columnIndices = new Map()
-  const indexRanges = []
-  const indexColumns = []
-
-  for (const columnName of columns) {
-    const colIndex = columnIndexMap.get(columnName)
-    if (colIndex === undefined) continue
-
-    const column = rowGroup.columns[colIndex]
-    if (!column.meta_data?.path_in_schema?.length || !column.offset_index_offset) continue
-
-    // Add index ranges to batch
-    indexRanges.push([Number(column.column_index_offset), Number(column.column_index_offset) + Number(column.column_index_length)])
-    indexRanges.push([Number(column.offset_index_offset), Number(column.offset_index_offset) + Number(column.offset_index_length)])
-    indexColumns.push(column)
-  }
-
-  // Batch read all indices
-  if (indexRanges.length > 0) {
-    const indexBuffers = await sliceAll(file, indexRanges)
-
-    // Parse indices
-    for (let i = 0; i < indexColumns.length; i++) {
-      const column = indexColumns[i]
-      const colIndexData = indexBuffers[i * 2]
-      const offsetIndexData = indexBuffers[i * 2 + 1]
-
-      const schemaPath = getSchemaPath(metadata.schema, column.meta_data.path_in_schema)
-      const element = schemaPath[schemaPath.length - 1]?.element
-
-      columnIndices.set(column, {
-        columnIndex: readColumnIndex({ view: new DataView(colIndexData), offset: 0 }, element),
-        offsetIndex: readOffsetIndex({ view: new DataView(offsetIndexData), offset: 0 }),
-      })
-    }
-  }
-
-  // Now read the actual data pages we selected
-  const columnData = await readSelectedPages(file, metadata, rowGroup, columns, pageSelections, columnIndexMap, columnIndices, options)
+  // Read column data from selected pages
+  const columnData = await readSelectedPages(
+    file, metadata, rowGroup, columns, selectedPages, columnIndexMap, options
+  )
 
   // Assemble into rows
   return assembleRows(columnData, columns)
@@ -372,16 +260,15 @@ async function readRowGroupWithPageFilter(file, metadata, rgIndex, predicates, c
  * Select pages that might contain matching rows
  * @param {AsyncBuffer} file
  * @param {FileMetaData} metadata
- * @param {object} rowGroup
- * @param {Map<string, Function>} predicates
+ * @param {RowGroup} rowGroup
+ * @param {Map<string, (min: any, max: any) => boolean>} predicates
  * @param {Map<string, number>} columnIndexMap
  * @returns {Promise<Set<number>|null>}
  */
-async function selectPages(file, metadata, rowGroup, predicates, columnIndexMap) {
-  const pageSelections = new Map() // column index -> Set of page indices
+export async function selectPages(file, metadata, rowGroup, predicates, columnIndexMap) {
+  const pageSelections = new Map()
   let hasAnyPages = false
 
-  // Each column's pages are checked independently
   for (const [columnName, predicate] of predicates) {
     const colIndex = columnIndexMap.get(columnName)
     if (colIndex === undefined) continue
@@ -389,10 +276,10 @@ async function selectPages(file, metadata, rowGroup, predicates, columnIndexMap)
     const column = rowGroup.columns[colIndex]
     if (!column.column_index_offset) continue
 
-    // Read column and offset indices
+    // Read indices
     const indices = await readIndices(file, column, metadata.schema)
 
-    // Find pages that might match
+    // Find matching pages
     const matchingPages = new Set()
     for (let i = 0; i < indices.columnIndex.min_values.length; i++) {
       if (predicate(indices.columnIndex.min_values[i], indices.columnIndex.max_values[i])) {
@@ -408,13 +295,12 @@ async function selectPages(file, metadata, rowGroup, predicates, columnIndexMap)
 
   if (!hasAnyPages) return null
 
-  // AND semantics: a page must satisfy all predicates to be included
+  // AND semantics: intersect all column selections
   let selectedPages = null
   for (const pages of pageSelections.values()) {
     if (selectedPages === null) {
       selectedPages = new Set(pages)
     } else {
-      // Intersect with previous selections
       selectedPages = new Set([...selectedPages].filter((p) => pages.has(p)))
     }
   }
@@ -425,12 +311,11 @@ async function selectPages(file, metadata, rowGroup, predicates, columnIndexMap)
 /**
  * Read indices for a column
  * @param {AsyncBuffer} file
- * @param {object} column
- * @param {object[]} schema
- * @returns {Promise<{columnIndex: object, offsetIndex: object}>}
+ * @param {ColumnChunk} column
+ * @param {SchemaElement[]} schema
+ * @returns {Promise<{columnIndex: ColumnIndex, offsetIndex: OffsetIndex}>}
  */
-async function readIndices(file, column, schema) {
-  // Read both indices in one operation instead of two
+export async function readIndices(file, column, schema) {
   const ranges = [
     [Number(column.column_index_offset), Number(column.column_index_offset) + Number(column.column_index_length)],
     [Number(column.offset_index_offset), Number(column.offset_index_offset) + Number(column.offset_index_length)],
@@ -438,16 +323,8 @@ async function readIndices(file, column, schema) {
 
   const [colIndexData, offsetIndexData] = await sliceAll(file, ranges)
 
-  // Parse indices
-  const pathInSchema = column.meta_data?.path_in_schema || []
-  if (!pathInSchema.length) {
-    throw new Error('Column missing path_in_schema')
-  }
-  const schemaPath = getSchemaPath(schema, pathInSchema)
+  const schemaPath = getSchemaPath(schema, column.meta_data.path_in_schema)
   const element = schemaPath[schemaPath.length - 1]?.element
-  if (!element) {
-    throw new Error('Schema element not found for column')
-  }
 
   return {
     columnIndex: readColumnIndex({ view: new DataView(colIndexData), offset: 0 }, element),
@@ -456,23 +333,19 @@ async function readIndices(file, column, schema) {
 }
 
 /**
- * Read selected pages for columns with batched I/O
+ * Read selected pages for columns
  * @param {AsyncBuffer} file
  * @param {FileMetaData} metadata
- * @param {object} rowGroup
+ * @param {RowGroup} rowGroup
  * @param {string[]} columns
- * @param {Set<number>|null} selectedPages
+ * @param {Set<number>} selectedPages
  * @param {Map<string, number>} columnIndexMap
- * @param {Map<object, object>} columnIndices
  * @param {object} options
  * @returns {Promise<Map<string, any[]>>}
  */
-async function readSelectedPages(file, metadata, rowGroup, columns, selectedPages, columnIndexMap, columnIndices, options) {
+export async function readSelectedPages(file, metadata, rowGroup, columns, selectedPages, columnIndexMap, options) {
   const columnData = new Map()
-  const pageReadPlan = []
-  const pageReadColumns = []
 
-  // Collect all ranges first so we can batch the reads
   for (const columnName of columns) {
     const colIndex = columnIndexMap.get(columnName)
     if (colIndex === undefined) continue
@@ -480,116 +353,43 @@ async function readSelectedPages(file, metadata, rowGroup, columns, selectedPage
     const column = rowGroup.columns[colIndex]
     if (!column.meta_data) continue
 
-    // If we have indices and selected pages, plan page-level reads
-    if (selectedPages && columnIndices.has(column)) {
-      const indices = columnIndices.get(column)
-      const selectedPagesList = Array.from(selectedPages).sort((a, b) => a - b)
-
-      // Dictionary needed for decoding dictionary-encoded pages
-      if (column.meta_data.dictionary_page_offset) {
-        pageReadPlan.push({
-          range: [Number(column.meta_data.dictionary_page_offset), Number(column.meta_data.data_page_offset)],
-          column,
-          columnName,
-          isDictionary: true,
-        })
-      }
-
-      // Add page reads
-      for (const pageIdx of selectedPagesList) {
-        const location = indices.offsetIndex.page_locations[pageIdx]
-        pageReadPlan.push({
-          range: [Number(location.offset), Number(location.offset) + location.compressed_page_size],
-          column,
-          columnName,
-          pageIdx,
-          location,
-          indices,
-        })
-      }
-      pageReadColumns.push({ column, columnName, selectedPagesList, indices })
-    } else {
-      // No page filtering, read all column data
-      const start = Number(column.meta_data.dictionary_page_offset || column.meta_data.data_page_offset)
-      const size = Number(column.meta_data.total_compressed_size)
-      pageReadPlan.push({
-        range: [start, start + size],
-        column,
-        columnName,
-        isFullColumn: true,
-      })
+    // Read full column if no page selection
+    if (!selectedPages || !column.offset_index_offset) {
+      const data = await readFullColumn(file, metadata, rowGroup, column, options)
+      columnData.set(columnName, data)
+      continue
     }
-  }
 
-  // Execute all reads in one batch operation
-  const allRanges = pageReadPlan.map((p) => p.range)
-  const allBuffers = await sliceAll(file, allRanges)
+    // Read indices
+    const indices = await readIndices(file, column, metadata.schema)
+    const selectedPagesList = Array.from(selectedPages).sort((a, b) => a - b)
 
-  // Process results
-  let bufferIdx = 0
-  const columnDictionaries = new Map()
-  const columnPageData = new Map()
+    // Collect page ranges
+    const pageRanges = []
+    let needsDictionary = false
 
-  for (const plan of pageReadPlan) {
-    const buffer = allBuffers[bufferIdx++]
-
-    if (plan.isDictionary) {
-      columnDictionaries.set(plan.column, buffer)
-    } else if (plan.isFullColumn) {
-      // Full column read, no page-level filtering
-      const schemaPath = getSchemaPath(metadata.schema, plan.column.meta_data.path_in_schema)
-      const reader = { view: new DataView(buffer), offset: 0 }
-
-      const values = readColumn(
-        reader,
-        {
-          groupStart: 0,
-          selectStart: 0,
-          selectEnd: Number(plan.column.meta_data.num_values),
-          groupRows: Number(rowGroup.num_rows),
-        },
-        {
-          columnName: plan.column.meta_data.path_in_schema.join('.'),
-          type: plan.column.meta_data.type,
-          element: schemaPath[schemaPath.length - 1].element,
-          schemaPath,
-          codec: plan.column.meta_data.codec,
-          parsers: options.parsers || DEFAULT_PARSERS,
-          compressors: options.compressors,
-          utf8: options.utf8 !== false,
-        }
-      )
-
-      // readColumn may return multiple chunks that need flattening
-      const flatValues = []
-      if (Array.isArray(values)) {
-        for (const chunk of values) {
-          concat(flatValues, chunk)
-        }
-      }
-      columnData.set(plan.columnName, flatValues)
-    } else {
-      // Collect page data for later assembly
-      if (!columnPageData.has(plan.column)) {
-        columnPageData.set(plan.column, [])
-      }
-      columnPageData.get(plan.column).push({
-        buffer,
-        pageIdx: plan.pageIdx,
-        location: plan.location,
-      })
+    if (column.meta_data.dictionary_page_offset) {
+      needsDictionary = true
+      pageRanges.push([
+        Number(column.meta_data.dictionary_page_offset),
+        Number(column.meta_data.data_page_offset),
+      ])
     }
-  }
 
-  // Combine all pages into complete column data
-  for (const { column, columnName, indices } of pageReadColumns) {
-    if (!columnPageData.has(column)) continue
+    for (const pageIdx of selectedPagesList) {
+      const location = indices.offsetIndex.page_locations[pageIdx]
+      pageRanges.push([
+        Number(location.offset),
+        Number(location.offset) + location.compressed_page_size,
+      ])
+    }
 
-    const pages = columnPageData.get(column)
-    const dictionary = columnDictionaries.get(column)
+    // Read all pages
+    const pageBuffers = await sliceAll(file, pageRanges)
+    const dictionary = needsDictionary ? pageBuffers.shift() : null
+
+    // Decode pages
     const schemaPath = getSchemaPath(metadata.schema, column.meta_data.path_in_schema)
-    const allValues = []
-
     const columnDecoder = {
       columnName: column.meta_data.path_in_schema.join('.'),
       type: column.meta_data.type,
@@ -601,36 +401,30 @@ async function readSelectedPages(file, metadata, rowGroup, columns, selectedPage
       utf8: options.utf8 !== false,
     }
 
-    for (const { buffer, pageIdx, location } of pages) {
-      // Parquet requires dictionary before data for dictionary encoding
-      let fullBuffer
-      // let readerOffset = 0
+    const allValues = []
+    for (let i = 0; i < selectedPagesList.length; i++) {
+      const pageIdx = selectedPagesList[i]
+      const pageBuffer = pageBuffers[i]
+      const location = indices.offsetIndex.page_locations[pageIdx]
 
+      // Combine dictionary and page if needed
+      let fullBuffer = pageBuffer
       if (dictionary) {
-        // Single allocation is more efficient than multiple concatenations
-        const dictSize = dictionary.byteLength
-        const pageSize = buffer.byteLength
-        fullBuffer = new ArrayBuffer(dictSize + pageSize)
-        new Uint8Array(fullBuffer).set(new Uint8Array(dictionary), 0)
-        new Uint8Array(fullBuffer).set(new Uint8Array(buffer), dictSize)
-        // readerOffset = dictSize
-      } else {
-        fullBuffer = buffer
+        const combined = new ArrayBuffer(dictionary.byteLength + pageBuffer.byteLength)
+        new Uint8Array(combined).set(new Uint8Array(dictionary), 0)
+        new Uint8Array(combined).set(new Uint8Array(pageBuffer), dictionary.byteLength)
+        fullBuffer = combined
       }
 
-      const reader = {
-        view: new DataView(fullBuffer),
-        offset: 0, // Always start at 0 so readColumn can parse the dictionary header
-      }
-
-      // Offset index tells us how many rows are in each page
+      // Calculate page row count
       const pageFirstRow = Number(location.first_row_index)
       const nextLocation = indices.offsetIndex.page_locations[pageIdx + 1]
       const pageRowCount = nextLocation
         ? Number(nextLocation.first_row_index) - pageFirstRow
         : Number(column.meta_data.num_values) - pageFirstRow
 
-      // Read this specific page's data
+      // Read page
+      const reader = { view: new DataView(fullBuffer), offset: 0 }
       const pageValues = readColumn(
         reader,
         {
@@ -642,24 +436,12 @@ async function readSelectedPages(file, metadata, rowGroup, columns, selectedPage
         columnDecoder
       )
 
-      // readColumn may return multiple chunks that need flattening
-
+      // Flatten values
       if (Array.isArray(pageValues)) {
         for (const chunk of pageValues) {
-          if (Array.isArray(chunk)) {
-            // concat handles typed arrays efficiently
-            if (chunk.slice && typeof chunk.slice === 'function' && chunk.constructor !== Array) {
-              concat(allValues, chunk)
-            } else {
-              allValues.push(...chunk)
-            }
-          } else {
-            // Single values just get pushed
-            allValues.push(chunk)
-          }
+          concat(allValues, chunk)
         }
       } else {
-        // Non-array means single value
         allValues.push(pageValues)
       }
     }
@@ -671,27 +453,63 @@ async function readSelectedPages(file, metadata, rowGroup, columns, selectedPage
 }
 
 /**
- * Read entire row group without filtering
+ * Read full column without page filtering
  * @param {AsyncBuffer} file
  * @param {FileMetaData} metadata
- * @param {number} rgIndex
- * @param {string[]} columns
+ * @param {RowGroup} rowGroup
+ * @param {ColumnChunk} column
  * @param {object} options
- * @param {number} groupStart
- * @returns {Promise<object[]>}
+ * @returns {Promise<DecodedArray>}
  */
-async function readRowGroup(file, metadata, rgIndex, columns, options, groupStart) {
-  const rowGroup = metadata.row_groups[rgIndex]
-  const groupEnd = groupStart + Number(rowGroup.num_rows)
+export async function readFullColumn(file, metadata, rowGroup, column, options) {
+  const start = Number(column.meta_data?.dictionary_page_offset || column.meta_data?.data_page_offset)
+  const size = Number(column.meta_data?.total_compressed_size)
+  const buffer = await file.slice(start, start + size)
 
-  return await parquetReadObjects({
-    file,
-    metadata,
-    columns,
-    rowStart: groupStart,
-    rowEnd: groupEnd,
-    ...options,
-  })
+  const schemaPath = getSchemaPath(metadata.schema, column.meta_data?.path_in_schema || [])
+  const reader = { view: new DataView(buffer), offset: 0 }
+
+  const values = readColumn(
+    reader,
+    {
+      groupStart: 0,
+      selectStart: 0,
+      selectEnd: Number(column.meta_data?.num_values),
+      groupRows: Number(rowGroup.num_rows),
+    },
+    {
+      columnName: column.meta_data?.path_in_schema.join('.'),
+      type: column.meta_data?.type,
+      element: schemaPath[schemaPath.length - 1].element,
+      schemaPath,
+      codec: column.meta_data?.codec,
+      parsers: options.parsers || DEFAULT_PARSERS,
+      compressors: options.compressors,
+      utf8: options.utf8 !== false,
+    }
+  )
+
+  /** @type {DecodedArray} Flattened values if needed */
+  const flatValues = []
+  if (Array.isArray(values)) {
+    for (const chunk of values) {
+      concat(flatValues, chunk)
+    }
+  }
+  return flatValues
+}
+
+/**
+ * Batch read multiple byte ranges
+ * @param {AsyncBuffer} file
+ * @param {Array<[number, number]|null>} ranges
+ * @returns {Promise<ArrayBuffer[]>}
+ */
+export function sliceAll(file, ranges) {
+  return (
+    file.sliceAll?.(ranges) ??
+    Promise.all(ranges.map((range) => range ? file.slice(range[0], range[1]) : Promise.resolve(new ArrayBuffer(0))))
+  )
 }
 
 /**
@@ -700,7 +518,7 @@ async function readRowGroup(file, metadata, rgIndex, columns, options, groupStar
  * @param {string[]} columns
  * @returns {object[]}
  */
-function assembleRows(columnData, columns) {
+export function assembleRows(columnData, columns) {
   if (columnData.size === 0) return []
 
   const numRows = Math.max(...[...columnData.values()].map((d) => d.length))
@@ -710,11 +528,7 @@ function assembleRows(columnData, columns) {
     const row = {}
     for (const col of columns) {
       const data = columnData.get(col)
-      if (data && Array.isArray(data)) {
-        row[col] = data[i] !== undefined ? data[i] : null
-      } else {
-        row[col] = null
-      }
+      row[col] = data?.[i] ?? null
     }
     rows.push(row)
   }
@@ -723,107 +537,12 @@ function assembleRows(columnData, columns) {
 }
 
 /**
- * Create column name to index mapping for a row group
- * @param {object} rowGroup
- * @returns {Map<string, number>}
- */
-function createColumnIndexMap(rowGroup) {
-  const map = new Map()
-  rowGroup.columns.forEach((column, index) => {
-    if (column.meta_data?.path_in_schema) {
-      // Only map top-level column names for now
-      if (column.meta_data.path_in_schema.length > 0) {
-        map.set(column.meta_data.path_in_schema[0], index)
-      }
-    }
-  })
-  return map
-}
-
-/**
- * Create predicates from MongoDB-style filter
- * @param {object} filter
- * @returns {Map<string, Function>}
- */
-function createPredicates(filter) {
-  const predicates = new Map()
-
-  function addPredicate(column, condition) {
-    const pred = createRangePredicate(condition)
-    if (pred) {
-      predicates.set(column, pred)
-    }
-  }
-
-  function processFilter(f) {
-    if (f.$and) {
-      f.$and.forEach(processFilter)
-    } else if (f.$or) {
-      // OR predicates across different columns can't use statistics effectively
-    } else {
-      // Process column-level conditions
-      for (const [col, cond] of Object.entries(f)) {
-        if (!col.startsWith('$')) {
-          addPredicate(col, cond)
-        }
-      }
-    }
-  }
-
-  processFilter(filter)
-  return predicates
-}
-
-/**
- * Create range predicate from condition
- * @param {any} condition
- * @returns {Function|null}
- */
-function createRangePredicate(condition) {
-  // Handle direct value comparison
-  if (typeof condition !== 'object' || condition === null) {
-    return (min, max) => min <= condition && condition <= max
-  }
-
-  const { $eq, $gt, $gte, $lt, $lte, $in } = condition
-
-  // Create a function that checks if a [min,max] range could contain values
-  // that satisfy the condition. Used for row group and page filtering.
-  return (min, max) => {
-    if ($eq !== undefined) {
-      return min <= $eq && $eq <= max
-    }
-
-    if ($in && Array.isArray($in)) {
-      return $in.some((v) => min <= v && v <= max)
-    }
-
-    let possible = true
-
-    if ($gt !== undefined) {
-      possible = possible && max > $gt
-    }
-    if ($gte !== undefined) {
-      possible = possible && max >= $gte
-    }
-    if ($lt !== undefined) {
-      possible = possible && min < $lt
-    }
-    if ($lte !== undefined) {
-      possible = possible && min <= $lte
-    }
-
-    return possible
-  }
-}
-
-/**
- * Check if row matches filter exactly
+ * Check if row matches filter
  * @param {object} row
- * @param {object} filter
+ * @param {any} filter
  * @returns {boolean}
  */
-function matchesFilter(row, filter) {
+export function matchesFilter(row, filter) {
   if (filter.$and) {
     return filter.$and.every((f) => matchesFilter(row, f))
   }
@@ -845,8 +564,7 @@ function matchesFilter(row, filter) {
     if (col.startsWith('$')) continue
 
     const value = row[col]
-    const matches = matchesCondition(value, cond)
-    if (!matches) {
+    if (!matchesCondition(value, cond)) {
       return false
     }
   }
@@ -860,13 +578,13 @@ function matchesFilter(row, filter) {
  * @param {any} condition
  * @returns {boolean}
  */
-function matchesCondition(value, condition) {
-  // Handle direct value comparison (including arrays)
+export function matchesCondition(value, condition) {
+  // Handle direct value comparison
   if (typeof condition !== 'object' || condition === null || Array.isArray(condition)) {
     return equals(value, condition)
   }
 
-  // MongoDB semantics: all operators on a field must be satisfied
+  // All operators must be satisfied
   for (const [op, target] of Object.entries(condition)) {
     switch (op) {
     case '$eq':
@@ -894,7 +612,6 @@ function matchesCondition(value, condition) {
       if (!Array.isArray(target) || target.includes(value)) return false
       break
     case '$not':
-      // $not inverts the entire condition
       if (matchesCondition(value, target)) return false
       break
     }
@@ -905,18 +622,17 @@ function matchesCondition(value, condition) {
 
 /**
  * Sort rows by column
- * @param {object[]} rows
+ * @param {any[]} rows
  * @param {string} orderBy
  * @param {boolean} desc
- * @returns {object[]}
  */
-function sortRows(rows, orderBy, desc) {
-  return [...rows].sort((a, b) => {
+export function sortRows(rows, orderBy, desc) {
+  rows.sort((a, b) => {
     const aVal = a[orderBy]
     const bVal = b[orderBy]
 
     if (aVal === bVal) {
-      // Use __index__ to ensure stable sorting
+      // Use __index__ for stable sort
       if (a.__index__ !== undefined && b.__index__ !== undefined) {
         return a.__index__ - b.__index__
       }
@@ -943,31 +659,3 @@ export function projectRow(row, columns) {
   }
   return projected
 }
-
-/**
- * Extract column names from filter
- * @param {object} filter
- * @returns {string[]}
- */
-export function extractFilterColumns(filter) {
-  const columns = new Set()
-
-  function extract(f) {
-    if (f.$and || f.$or || f.$nor) {
-      (f.$and || f.$or || f.$nor).forEach(extract)
-    } else if (f.$not) {
-      extract(f.$not)
-    } else {
-      Object.keys(f).forEach((k) => {
-        if (!k.startsWith('$')) columns.add(k)
-      })
-    }
-  }
-
-  extract(filter)
-  return [...columns]
-}
-
-/**
- * @import {AsyncBuffer, FileMetaData, CompressionCodec, Compressors, ParquetParsers} from './types.d.ts'
- */

--- a/src/query.js
+++ b/src/query.js
@@ -609,7 +609,7 @@ export function matchesCondition(value, condition) {
 
 /**
  * Sort rows by column
- * @param {any[]} rows
+ * @param {Record<string, any>[]} rows
  * @param {string} orderBy
  * @param {boolean} desc
  */
@@ -620,8 +620,10 @@ export function sortRows(rows, orderBy, desc) {
 
     if (aVal === bVal) {
       // Use __index__ for stable sort
-      if (/** @type {any} */ a.__index__ !== undefined && /** @type {any} */ b.__index__ !== undefined) {
-        return /** @type {any} */ a.__index__ - /** @type {any} */ b.__index__
+      const aIndex = a.__index__
+      const bIndex = b.__index__
+      if (aIndex !== undefined && bIndex !== undefined) {
+        return aIndex - bIndex
       }
       return 0
     }
@@ -637,13 +639,13 @@ export function sortRows(rows, orderBy, desc) {
  * Project row to selected columns
  * @param {{[key: string]: any}} row
  * @param {string[]} columns
- * @returns {object}
+ * @returns {{[key: string]: any}}
  */
 export function projectRow(row, columns) {
   /** @type {{[key: string]: any}} */
   const projected = {}
   for (const col of columns) {
-    projected[col] = /** @type {{[key: string]: any}} */ row[col]
+    projected[col] = row[col]
   }
   return projected
 }

--- a/src/query.js
+++ b/src/query.js
@@ -80,7 +80,7 @@ export async function parquetQuery(options) {
       groupData = groupData.filter((row) => matchesFilter(row, filter))
     }
 
-    rows.push(...groupData)
+    concat(rows, groupData)
 
     // Early exit for limited queries without sorting
     if (!orderBy && limit !== undefined && rows.length >= offset + limit) {
@@ -506,8 +506,7 @@ export function sliceAll(file, ranges) {
  */
 export function assembleRows(columnData, columns) {
   if (columnData.size === 0) return []
-
-  const numRows = Math.max(...[...columnData.values()].map((d) => d.length))
+  const numRows = max(...[...columnData.values()].map((d) => d.length))
   const rows = []
 
   for (let i = 0; i < numRows; i++) {

--- a/src/query.js
+++ b/src/query.js
@@ -506,7 +506,7 @@ export function sliceAll(file, ranges) {
  */
 export function assembleRows(columnData, columns) {
   if (columnData.size === 0) return []
-  const numRows = max(...[...columnData.values()].map((d) => d.length))
+  const numRows = [...columnData.values()].reduce((max, d) => Math.max(max, d.length), 0)
   const rows = []
 
   for (let i = 0; i < numRows; i++) {

--- a/src/query.js
+++ b/src/query.js
@@ -53,10 +53,11 @@ export async function parquetQuery(options) {
     throw new Error(`parquet orderBy column not found: ${orderBy}`)
   }
 
-  // Main processing loop
+  /** @type {Record<string, any>[]} */
   const rows = []
   let groupStart = 0
 
+  // Main processing loop
   for (let rgIndex = 0; rgIndex < metadata.row_groups.length; rgIndex++) {
     const rowGroup = metadata.row_groups[rgIndex]
     const groupRows = Number(rowGroup.num_rows)

--- a/src/query.js
+++ b/src/query.js
@@ -71,12 +71,9 @@ export async function parquetQuery(options) {
     const { size } = getRowGroupFullRange(rowGroup)
     const useSmallGroupOptimization = size < 4 * 1024 * 1024
 
-    let groupData
-    if (useSmallGroupOptimization) {
-      groupData = await readSmallRowGroup(file, metadata, rgIndex, predicates, requiredColumns, options, groupStart)
-    } else {
-      groupData = await readLargeRowGroup(file, metadata, rgIndex, predicates, requiredColumns, options, groupStart)
-    }
+    /** @type {typeof readSmallRowGroup | typeof readLargeRowGroup} */
+    const groupDataFn = useSmallGroupOptimization ? readSmallRowGroup : readLargeRowGroup
+    let groupData = await groupDataFn(file, metadata, rgIndex, predicates, requiredColumns, options, groupStart)
 
     // Apply filter if needed
     if (filter) {

--- a/src/query.js
+++ b/src/query.js
@@ -1,252 +1,973 @@
-import { parquetReadObjects } from './index.js'
+/**
+ * Query implementation with predicate pushdown.
+ * Uses Parquet statistics to skip data that doesn't match filters.
+ */
+
+import { readColumnIndex, readOffsetIndex } from './indexes.js'
 import { parquetMetadataAsync, parquetSchema } from './metadata.js'
-import { parquetReadColumn } from './read.js'
-import { equals } from './utils.js'
+import { getSchemaPath } from './schema.js'
+import { readColumn } from './column.js'
+import { parquetReadObjects } from './index.js'
+import { DEFAULT_PARSERS } from './convert.js'
+import { concat, equals } from './utils.js'
 
 /**
- * Wraps parquetRead with filter and orderBy support.
- * This is a parquet-aware query engine that can read a subset of rows and columns.
- * Accepts optional filter object to filter the results and orderBy column name to sort the results.
- * Note that using orderBy may SIGNIFICANTLY increase the query time.
- *
- * @param {ParquetReadOptions & { filter?: ParquetQueryFilter, orderBy?: string }} options
- * @returns {Promise<Record<string, any>[]>} resolves when all requested rows and columns are parsed
+ * Batch read multiple byte ranges from the file in a single operation.
+ * This reduces network round trips when reading from remote storage
+ * and allows the underlying implementation to optimize concurrent reads.
+ * @param {AsyncBuffer} file - File buffer
+ * @param {Array<[number, number] | null>} ranges - Array of byte ranges
+ * @returns {Promise<ArrayBuffer[]>} Array of buffers
+ */
+function sliceAll(file, ranges) {
+  return (
+    file.sliceAll?.(ranges) ??
+    Promise.all(ranges.map((range) => range ? file.slice(range[0], range[1]) : Promise.resolve(new ArrayBuffer(0))))
+  )
+}
+
+/**
+ * Calculate the total byte range of a row group including indices
+ * @param {object} rowGroup - Row group metadata
+ * @returns {{start: number, end: number, size: number}} - Byte range and size
+ */
+function getRowGroupFullRange(rowGroup) {
+  let start = Infinity
+  let end = 0
+
+  for (const col of rowGroup.columns) {
+    if (col.meta_data) {
+      // Column data range
+      const colStart = Number(col.meta_data.dictionary_page_offset || col.meta_data.data_page_offset)
+      const colEnd = colStart + Number(col.meta_data.total_compressed_size)
+      start = Math.min(start, colStart)
+      end = Math.max(end, colEnd)
+
+      // Include column index if present
+      if (col.column_index_offset) {
+        const indexEnd = Number(col.column_index_offset) + Number(col.column_index_length)
+        end = Math.max(end, indexEnd)
+      }
+
+      // Include offset index if present
+      if (col.offset_index_offset) {
+        const offsetEnd = Number(col.offset_index_offset) + Number(col.offset_index_length)
+        end = Math.max(end, offsetEnd)
+      }
+    }
+  }
+
+  return { start, end, size: end - start }
+}
+
+/**
+ * Query parquet file with predicate pushdown optimization
+ * @param {object} options - Query options
+ * @param {AsyncBuffer} options.file - Parquet file buffer
+ * @param {FileMetaData} [options.metadata] - Parquet metadata (will be loaded if not provided)
+ * @param {object} [options.filter] - MongoDB-style filter
+ * @param {string[]} [options.columns] - Columns to return
+ * @param {string} [options.orderBy] - Column to sort by
+ * @param {boolean} [options.desc] - Sort descending
+ * @param {number} [options.rowStart] - First row to return (inclusive)
+ * @param {number} [options.rowEnd] - Last row to return (exclusive)
+ * @param {number} [options.offset] - Skip this many rows (alternative to rowStart)
+ * @param {number} [options.limit] - Return at most this many rows (alternative to rowEnd)
+ * @param {Compressors} [options.compressors] - Custom decompressors
+ * @param {boolean} [options.utf8] - Decode byte arrays as utf8 strings
+ * @param {ParquetParsers} [options.parsers] - Custom parsers
+ * @returns {Promise<object[]>} Array of row objects
  */
 export async function parquetQuery(options) {
-  if (!options.file || !(options.file.byteLength >= 0)) {
-    throw new Error('parquet expected AsyncBuffer')
-  }
-  options.metadata ??= await parquetMetadataAsync(options.file)
+  const { file, filter, columns, orderBy, desc = false } = options
+  const metadata = options.metadata || await parquetMetadataAsync(file)
 
-  const { metadata, rowStart = 0, columns, orderBy, filter } = options
-  if (rowStart < 0) throw new Error('parquet rowStart must be positive')
-  const rowEnd = options.rowEnd ?? Number(metadata.num_rows)
+  // Support both APIs since users might use either style
+  const offset = options.offset ?? options.rowStart ?? 0
+  if (offset < 0) throw new Error('parquet rowStart must be positive')
+  const limit = options.limit ?? (options.rowEnd !== undefined ? options.rowEnd - offset : undefined)
 
-  // Collect columns needed for the query
-  const filterColumns = columnsNeededForFilter(filter)
-  const allColumns = parquetSchema(options.metadata).children.map(c => c.element.name)
-  // Check if all filter columns exist
-  const missingColumns = filterColumns.filter(column => !allColumns.includes(column))
-  if (missingColumns.length) {
-    throw new Error(`parquet filter columns not found: ${missingColumns.join(', ')}`)
+  // Get schema once since we'll reference it multiple times
+  const schema = parquetSchema(metadata)
+  const allColumns = schema.children.map((c) => c.element.name)
+
+  // Need both output columns and filter columns for evaluation
+  const filterColumns = filter ? extractFilterColumns(filter) : []
+  const outputColumns = columns || allColumns
+  const requiredColumns = new Set([...outputColumns, ...filterColumns, orderBy].filter(Boolean))
+
+  // Convert filter to predicates that can test min/max statistics
+  const predicates = filter ? createPredicates(filter) : new Map()
+
+  // Validate columns exist
+  if (filter) {
+    const filterColumns = extractFilterColumns(filter)
+    const missingColumns = filterColumns.filter((col) => !allColumns.includes(col))
+    if (missingColumns.length) {
+      throw new Error(`parquet filter columns not found: ${missingColumns.join(', ')}`)
+    }
   }
   if (orderBy && !allColumns.includes(orderBy)) {
     throw new Error(`parquet orderBy column not found: ${orderBy}`)
   }
-  const relevantColumns = columns ? allColumns.filter(column =>
-    columns.includes(column) || filterColumns.includes(column) || column === orderBy
-  ) : undefined
-  // Is the output a subset of the relevant columns?
-  const requiresProjection = columns && relevantColumns ? columns.length < relevantColumns.length : false
 
-  if (filter && !orderBy && rowEnd < metadata.num_rows) {
-    // iterate through row groups and filter until we have enough rows
-    const filteredRows = new Array()
+  // Can stream results when filtering without sorting and we know the limit
+  if (filter && !orderBy && limit !== undefined && offset + limit < Number(metadata.num_rows)) {
+    const filteredRows = []
     let groupStart = 0
-    for (const group of metadata.row_groups) {
-      const groupEnd = groupStart + Number(group.num_rows)
-      // TODO: if expected > group size, start fetching next groups
-      const groupData = await parquetReadObjects({
-        ...options,
-        rowStart: groupStart,
-        rowEnd: groupEnd,
-        columns: relevantColumns,
-      })
+
+    for (let rgIndex = 0; rgIndex < metadata.row_groups.length; rgIndex++) {
+      const rowGroup = metadata.row_groups[rgIndex]
+      const groupRows = Number(rowGroup.num_rows)
+
+      // Row group statistics let us skip entire groups without reading any data
+      if (!canRowGroupMatch(rowGroup, predicates)) {
+        groupStart += groupRows
+        continue
+      }
+
+      // Small row groups are more efficient to read in one shot than multiple reads
+      const { start: rgStart, end: rgEnd, size: rgSize } = getRowGroupFullRange(rowGroup)
+      const ROW_GROUP_SIZE_THRESHOLD = 4 * 1024 * 1024 // 4MB
+
+      let groupData
+
+      if (rgSize < ROW_GROUP_SIZE_THRESHOLD) {
+        // Read entire row group in one shot
+        const rgBuffer = await file.slice(rgStart, rgEnd)
+
+        // All subsequent reads will be served from this prefetched buffer
+        const bufferedFile = {
+          byteLength: file.byteLength,
+          slice(start, end) {
+            if (start >= rgStart && end <= rgEnd) {
+              return Promise.resolve(rgBuffer.slice(start - rgStart, end - rgStart))
+            }
+            return file.slice(start, end)
+          },
+          sliceAll(ranges) {
+            // All ranges in buffer means we can serve from memory
+            const allInBuffer = ranges.every((range) => !range || range[0] >= rgStart && range[1] <= rgEnd)
+
+            if (allInBuffer) {
+              return Promise.resolve(
+                ranges.map((range) => range ? rgBuffer.slice(range[0] - rgStart, range[1] - rgStart) : new ArrayBuffer(0))
+              )
+            }
+
+            // Otherwise delegate to original file
+            return sliceAll(file, ranges)
+          },
+        }
+
+        // Now read with the buffered file
+        const hasIndices = rowGroup.columns.some((col) => col.column_index_offset)
+
+        if (hasIndices && predicates.size > 0) {
+          groupData = await readRowGroupWithPageFilter(bufferedFile, metadata, rgIndex, predicates, [...requiredColumns], options)
+        } else {
+          groupData = await parquetReadObjects({
+            ...options,
+            file: bufferedFile,
+            metadata,
+            columns: [...requiredColumns],
+            rowStart: groupStart,
+            rowEnd: groupStart + groupRows,
+          })
+        }
+      } else {
+        // Large row groups read normally to avoid memory bloat
+        const hasIndices = rowGroup.columns.some((col) => col.column_index_offset)
+
+        if (hasIndices && predicates.size > 0) {
+          groupData = await readRowGroupWithPageFilter(file, metadata, rgIndex, predicates, [...requiredColumns], options)
+        } else {
+          groupData = await parquetReadObjects({
+            ...options,
+            file,
+            metadata,
+            columns: [...requiredColumns],
+            rowStart: groupStart,
+            rowEnd: groupStart + groupRows,
+          })
+        }
+      }
+
+      // Apply filter to each row as we read it
       for (const row of groupData) {
-        if (matchQuery(row, filter)) {
-          if (requiresProjection && relevantColumns) {
-            for (const column of relevantColumns) {
-              if (columns && !columns.includes(column)) {
-                delete row[column] // remove columns not in the projection
-              }
-            }
-          }
+        if (matchesFilter(row, filter)) {
           filteredRows.push(row)
-        }
-      }
-      if (filteredRows.length >= rowEnd) break
-      groupStart = groupEnd
-    }
-    return filteredRows.slice(rowStart, rowEnd)
-  } else if (filter) {
-    // read all rows, sort, and filter
-    const results = await parquetReadObjects({
-      ...options,
-      rowStart: undefined,
-      rowEnd: undefined,
-      columns: relevantColumns,
-    })
-    if (orderBy) results.sort((a, b) => compare(a[orderBy], b[orderBy]))
-    const filteredRows = new Array()
-    for (const row of results) {
-      if (matchQuery(row, filter)) {
-        if (requiresProjection && relevantColumns) {
-          for (const column of relevantColumns) {
-            if (columns && !columns.includes(column)) {
-              delete row[column] // remove columns not in the projection
-            }
+          // Early exit if we have enough rows
+          if (filteredRows.length >= offset + limit) {
+            const sliced = filteredRows.slice(offset, offset + limit)
+            return columns ? sliced.map((row) => projectRow(row, columns)) : sliced
           }
         }
-        filteredRows.push(row)
       }
-    }
-    return filteredRows.slice(rowStart, rowEnd)
-  } else if (typeof orderBy === 'string') {
-    // sorted but unfiltered: fetch orderBy column first
-    const orderColumn = await parquetReadColumn({ ...options, rowStart: undefined, rowEnd: undefined, columns: [orderBy] })
 
-    // compute row groups to fetch
-    const sortedIndices = Array.from(orderColumn, (_, index) => index)
-      .sort((a, b) => compare(orderColumn[a], orderColumn[b]))
-      .slice(rowStart, rowEnd)
-
-    const sparseData = await parquetReadRows({ ...options, rows: sortedIndices })
-    const data = sortedIndices.map(index => sparseData[index])
-    return data
-  } else {
-    return await parquetReadObjects(options)
-  }
-}
-
-/**
- * Reads a list rows from a parquet file, reading only the row groups that contain the rows.
- * Returns a sparse array of rows.
- * @import {ParquetQueryFilter, ParquetReadOptions} from '../src/types.d.ts'
- * @param {ParquetReadOptions & { rows: number[] }} options
- * @returns {Promise<Record<string, any>[]>}
- */
-async function parquetReadRows(options) {
-  const { file, rows } = options
-  options.metadata ||= await parquetMetadataAsync(file)
-  const { row_groups: rowGroups } = options.metadata
-  // Compute row groups to fetch
-  const groupIncluded = Array(rowGroups.length).fill(false)
-  let groupStart = 0
-  const groupEnds = rowGroups.map(group => groupStart += Number(group.num_rows))
-  for (const index of rows) {
-    const groupIndex = groupEnds.findIndex(end => index < end)
-    groupIncluded[groupIndex] = true
-  }
-
-  // Compute row ranges to fetch
-  const rowRanges = []
-  let rangeStart
-  groupStart = 0
-  for (let i = 0; i < groupIncluded.length; i++) {
-    const groupEnd = groupStart + Number(rowGroups[i].num_rows)
-    if (groupIncluded[i]) {
-      if (rangeStart === undefined) {
-        rangeStart = groupStart
-      }
-    } else {
-      if (rangeStart !== undefined) {
-        rowRanges.push([rangeStart, groupEnd])
-        rangeStart = undefined
-      }
-    }
-    groupStart = groupEnd
-  }
-  if (rangeStart !== undefined) {
-    rowRanges.push([rangeStart, groupStart])
-  }
-
-  // Fetch by row group and map to rows
-  const sparseData = new Array(Number(options.metadata.num_rows))
-  for (const [rangeStart, rangeEnd] of rowRanges) {
-    // TODO: fetch in parallel
-    const groupData = await parquetReadObjects({ ...options, rowStart: rangeStart, rowEnd: rangeEnd })
-    for (let i = rangeStart; i < rangeEnd; i++) {
-      sparseData[i] = groupData[i - rangeStart]
-      sparseData[i].__index__ = i
-    }
-  }
-  return sparseData
-}
-
-/**
- * @param {any} a
- * @param {any} b
- * @returns {number}
- */
-function compare(a, b) {
-  if (a < b) return -1
-  if (a > b) return 1
-  return 0 // TODO: null handling
-}
-
-/**
- * Match a record against a query filter
- *
- * @param {any} record
- * @param {ParquetQueryFilter} query
- * @returns {boolean}
- * @example matchQuery({ id: 1 }, { id: {$gte: 1} }) // true
- */
-export function matchQuery(record, query = {}) {
-  if ('$and' in query && Array.isArray(query.$and)) {
-    return query.$and.every(subQuery => matchQuery(record, subQuery))
-  }
-  if ('$or' in query && Array.isArray(query.$or)) {
-    return query.$or.some(subQuery => matchQuery(record, subQuery))
-  }
-  if ('$nor' in query && Array.isArray(query.$nor)) {
-    return !query.$nor.some(subQuery => matchQuery(record, subQuery))
-  }
-
-  return Object.entries(query).every(([field, condition]) => {
-    const value = record[field]
-
-    // implicit $eq for non-object conditions
-    if (typeof condition !== 'object' || condition === null || Array.isArray(condition)) {
-      return equals(value, condition)
+      groupStart += groupRows
     }
 
-    return Object.entries(condition || {}).every(([operator, target]) => {
-      switch (operator) {
-      case '$gt':
-        return value > target
-      case '$gte':
-        return value >= target
-      case '$lt':
-        return value < target
-      case '$lte':
-        return value <= target
-      case '$eq':
-        return equals(value, target)
-      case '$ne':
-        return !equals(value, target)
-      case '$in':
-        return Array.isArray(target) && target.includes(value)
-      case '$nin':
-        return Array.isArray(target) && !target.includes(value)
-      case '$not':
-        return !matchQuery({ [field]: value }, { [field]: target })
-      default:
-        return true
-      }
+    // May have fewer rows than limit if we ran out of data
+    const sliced = filteredRows.slice(offset, offset + limit)
+    return columns ? sliced.map((row) => projectRow(row, columns)) : sliced
+  }
+
+  // Can't stream when we need to sort or don't know how many rows we need
+  const readOptions = filter || orderBy ? { ...options, rowStart: undefined, rowEnd: undefined } : options
+  const rows = await readWithPushdown(file, metadata, predicates, [...requiredColumns], readOptions)
+
+  // Need original positions to maintain stable sort for equal values
+  if (orderBy && !filter) {
+    rows.forEach((row, idx) => {
+      row.__index__ = idx
     })
+  }
+
+  const filtered = filter ? rows.filter((row) => matchesFilter(row, filter)) : rows
+
+  // Order matters: filter first (reduce data), then sort, then slice, finally project
+  const sorted = orderBy ? sortRows(filtered, orderBy, desc) : filtered
+
+  // Slicing already done during read unless we filtered or sorted
+  const sliced = filter || orderBy ? sorted.slice(offset, limit ? offset + limit : undefined) : sorted
+
+  return columns ? sliced.map((row) => projectRow(row, columns)) : sliced
+}
+
+/**
+ * Read data with predicate pushdown
+ * @param {AsyncBuffer} file
+ * @param {FileMetaData} metadata
+ * @param {Map<string, Function>} predicates
+ * @param {string[]} columns
+ * @param {object} options
+ * @returns {Promise<object[]>}
+ */
+async function readWithPushdown(file, metadata, predicates, columns, options) {
+  const rows = []
+  let groupStart = 0
+
+  for (let rgIndex = 0; rgIndex < metadata.row_groups.length; rgIndex++) {
+    const rowGroup = metadata.row_groups[rgIndex]
+    const groupRows = Number(rowGroup.num_rows)
+
+    // Skip row groups that can't contain matches based on min/max statistics
+    if (!canRowGroupMatch(rowGroup, predicates)) {
+      groupStart += groupRows
+      continue
+    }
+
+    // Page indices provide finer-grained statistics than row groups
+    const hasIndices = rowGroup.columns.some((col) => col.column_index_offset)
+
+    if (hasIndices && predicates.size > 0) {
+      // Use page-level filtering
+      const groupData = await readRowGroupWithPageFilter(file, metadata, rgIndex, predicates, columns, options)
+      rows.push(...groupData)
+    } else {
+      // No indices available, read entire row group
+      const groupData = await readRowGroup(file, metadata, rgIndex, columns, { ...options, columns }, groupStart)
+      rows.push(...groupData)
+    }
+
+    groupStart += groupRows
+  }
+
+  return rows
+}
+
+/**
+ * Check if row group can contain matching rows based on statistics
+ * @param {object} rowGroup
+ * @param {Map<string, Function>} predicates
+ * @returns {boolean}
+ */
+function canRowGroupMatch(rowGroup, predicates) {
+  const columnIndexMap = createColumnIndexMap(rowGroup)
+
+  for (const [columnName, predicate] of predicates) {
+    const colIndex = columnIndexMap.get(columnName)
+    if (colIndex === undefined) continue
+
+    const column = rowGroup.columns[colIndex]
+    const stats = column?.meta_data?.statistics
+
+    if (stats?.min_value !== undefined && stats?.max_value !== undefined) {
+      if (!predicate(stats.min_value, stats.max_value)) {
+        return false // This row group cannot contain matches
+      }
+    }
+  }
+
+  return true
+}
+
+/**
+ * Read row group with page-level filtering
+ * @param {AsyncBuffer} file
+ * @param {FileMetaData} metadata
+ * @param {number} rgIndex
+ * @param {Map<string, Function>} predicates
+ * @param {string[]} columns
+ * @param {object} options
+ * @returns {Promise<object[]>}
+ */
+async function readRowGroupWithPageFilter(file, metadata, rgIndex, predicates, columns, options) {
+  const rowGroup = metadata.row_groups[rgIndex]
+  const columnIndexMap = createColumnIndexMap(rowGroup)
+
+  // Page statistics are more precise than row group statistics
+  const pageSelections = await selectPages(file, metadata, rowGroup, predicates, columnIndexMap)
+
+  // No matching pages means no matching rows
+  if (!pageSelections || pageSelections.size === 0) return []
+
+  // Read all indices together instead of one by one
+  const columnIndices = new Map()
+  const indexRanges = []
+  const indexColumns = []
+
+  for (const columnName of columns) {
+    const colIndex = columnIndexMap.get(columnName)
+    if (colIndex === undefined) continue
+
+    const column = rowGroup.columns[colIndex]
+    if (!column.meta_data?.path_in_schema?.length || !column.offset_index_offset) continue
+
+    // Add index ranges to batch
+    indexRanges.push([Number(column.column_index_offset), Number(column.column_index_offset) + Number(column.column_index_length)])
+    indexRanges.push([Number(column.offset_index_offset), Number(column.offset_index_offset) + Number(column.offset_index_length)])
+    indexColumns.push(column)
+  }
+
+  // Batch read all indices
+  if (indexRanges.length > 0) {
+    const indexBuffers = await sliceAll(file, indexRanges)
+
+    // Parse indices
+    for (let i = 0; i < indexColumns.length; i++) {
+      const column = indexColumns[i]
+      const colIndexData = indexBuffers[i * 2]
+      const offsetIndexData = indexBuffers[i * 2 + 1]
+
+      const schemaPath = getSchemaPath(metadata.schema, column.meta_data.path_in_schema)
+      const element = schemaPath[schemaPath.length - 1]?.element
+
+      columnIndices.set(column, {
+        columnIndex: readColumnIndex({ view: new DataView(colIndexData), offset: 0 }, element),
+        offsetIndex: readOffsetIndex({ view: new DataView(offsetIndexData), offset: 0 }),
+      })
+    }
+  }
+
+  // Now read the actual data pages we selected
+  const columnData = await readSelectedPages(file, metadata, rowGroup, columns, pageSelections, columnIndexMap, columnIndices, options)
+
+  // Assemble into rows
+  return assembleRows(columnData, columns)
+}
+
+/**
+ * Select pages that might contain matching rows
+ * @param {AsyncBuffer} file
+ * @param {FileMetaData} metadata
+ * @param {object} rowGroup
+ * @param {Map<string, Function>} predicates
+ * @param {Map<string, number>} columnIndexMap
+ * @returns {Promise<Set<number>|null>}
+ */
+async function selectPages(file, metadata, rowGroup, predicates, columnIndexMap) {
+  const pageSelections = new Map() // column index -> Set of page indices
+  let hasAnyPages = false
+
+  // Each column's pages are checked independently
+  for (const [columnName, predicate] of predicates) {
+    const colIndex = columnIndexMap.get(columnName)
+    if (colIndex === undefined) continue
+
+    const column = rowGroup.columns[colIndex]
+    if (!column.column_index_offset) continue
+
+    // Read column and offset indices
+    const indices = await readIndices(file, column, metadata.schema)
+
+    // Find pages that might match
+    const matchingPages = new Set()
+    for (let i = 0; i < indices.columnIndex.min_values.length; i++) {
+      if (predicate(indices.columnIndex.min_values[i], indices.columnIndex.max_values[i])) {
+        matchingPages.add(i)
+      }
+    }
+
+    if (matchingPages.size > 0) {
+      hasAnyPages = true
+      pageSelections.set(colIndex, matchingPages)
+    }
+  }
+
+  if (!hasAnyPages) return null
+
+  // AND semantics: a page must satisfy all predicates to be included
+  let selectedPages = null
+  for (const pages of pageSelections.values()) {
+    if (selectedPages === null) {
+      selectedPages = new Set(pages)
+    } else {
+      // Intersect with previous selections
+      selectedPages = new Set([...selectedPages].filter((p) => pages.has(p)))
+    }
+  }
+
+  return selectedPages
+}
+
+/**
+ * Read indices for a column
+ * @param {AsyncBuffer} file
+ * @param {object} column
+ * @param {object[]} schema
+ * @returns {Promise<{columnIndex: object, offsetIndex: object}>}
+ */
+async function readIndices(file, column, schema) {
+  // Read both indices in one operation instead of two
+  const ranges = [
+    [Number(column.column_index_offset), Number(column.column_index_offset) + Number(column.column_index_length)],
+    [Number(column.offset_index_offset), Number(column.offset_index_offset) + Number(column.offset_index_length)],
+  ]
+
+  const [colIndexData, offsetIndexData] = await sliceAll(file, ranges)
+
+  // Parse indices
+  const pathInSchema = column.meta_data?.path_in_schema || []
+  if (!pathInSchema.length) {
+    throw new Error('Column missing path_in_schema')
+  }
+  const schemaPath = getSchemaPath(schema, pathInSchema)
+  const element = schemaPath[schemaPath.length - 1]?.element
+  if (!element) {
+    throw new Error('Schema element not found for column')
+  }
+
+  return {
+    columnIndex: readColumnIndex({ view: new DataView(colIndexData), offset: 0 }, element),
+    offsetIndex: readOffsetIndex({ view: new DataView(offsetIndexData), offset: 0 }),
+  }
+}
+
+/**
+ * Read selected pages for columns with batched I/O
+ * @param {AsyncBuffer} file
+ * @param {FileMetaData} metadata
+ * @param {object} rowGroup
+ * @param {string[]} columns
+ * @param {Set<number>|null} selectedPages
+ * @param {Map<string, number>} columnIndexMap
+ * @param {Map<object, object>} columnIndices
+ * @param {object} options
+ * @returns {Promise<Map<string, any[]>>}
+ */
+async function readSelectedPages(file, metadata, rowGroup, columns, selectedPages, columnIndexMap, columnIndices, options) {
+  const columnData = new Map()
+  const pageReadPlan = []
+  const pageReadColumns = []
+
+  // Collect all ranges first so we can batch the reads
+  for (const columnName of columns) {
+    const colIndex = columnIndexMap.get(columnName)
+    if (colIndex === undefined) continue
+
+    const column = rowGroup.columns[colIndex]
+    if (!column.meta_data) continue
+
+    // If we have indices and selected pages, plan page-level reads
+    if (selectedPages && columnIndices.has(column)) {
+      const indices = columnIndices.get(column)
+      const selectedPagesList = Array.from(selectedPages).sort((a, b) => a - b)
+
+      // Dictionary needed for decoding dictionary-encoded pages
+      if (column.meta_data.dictionary_page_offset) {
+        pageReadPlan.push({
+          range: [Number(column.meta_data.dictionary_page_offset), Number(column.meta_data.data_page_offset)],
+          column,
+          columnName,
+          isDictionary: true,
+        })
+      }
+
+      // Add page reads
+      for (const pageIdx of selectedPagesList) {
+        const location = indices.offsetIndex.page_locations[pageIdx]
+        pageReadPlan.push({
+          range: [Number(location.offset), Number(location.offset) + location.compressed_page_size],
+          column,
+          columnName,
+          pageIdx,
+          location,
+          indices,
+        })
+      }
+      pageReadColumns.push({ column, columnName, selectedPagesList, indices })
+    } else {
+      // No page filtering, read all column data
+      const start = Number(column.meta_data.dictionary_page_offset || column.meta_data.data_page_offset)
+      const size = Number(column.meta_data.total_compressed_size)
+      pageReadPlan.push({
+        range: [start, start + size],
+        column,
+        columnName,
+        isFullColumn: true,
+      })
+    }
+  }
+
+  // Execute all reads in one batch operation
+  const allRanges = pageReadPlan.map((p) => p.range)
+  const allBuffers = await sliceAll(file, allRanges)
+
+  // Process results
+  let bufferIdx = 0
+  const columnDictionaries = new Map()
+  const columnPageData = new Map()
+
+  for (const plan of pageReadPlan) {
+    const buffer = allBuffers[bufferIdx++]
+
+    if (plan.isDictionary) {
+      columnDictionaries.set(plan.column, buffer)
+    } else if (plan.isFullColumn) {
+      // Full column read, no page-level filtering
+      const schemaPath = getSchemaPath(metadata.schema, plan.column.meta_data.path_in_schema)
+      const reader = { view: new DataView(buffer), offset: 0 }
+
+      const values = readColumn(
+        reader,
+        {
+          groupStart: 0,
+          selectStart: 0,
+          selectEnd: Number(plan.column.meta_data.num_values),
+          groupRows: Number(rowGroup.num_rows),
+        },
+        {
+          columnName: plan.column.meta_data.path_in_schema.join('.'),
+          type: plan.column.meta_data.type,
+          element: schemaPath[schemaPath.length - 1].element,
+          schemaPath,
+          codec: plan.column.meta_data.codec,
+          parsers: options.parsers || DEFAULT_PARSERS,
+          compressors: options.compressors,
+          utf8: options.utf8 !== false,
+        }
+      )
+
+      // readColumn may return multiple chunks that need flattening
+      const flatValues = []
+      if (Array.isArray(values)) {
+        for (const chunk of values) {
+          concat(flatValues, chunk)
+        }
+      }
+      columnData.set(plan.columnName, flatValues)
+    } else {
+      // Collect page data for later assembly
+      if (!columnPageData.has(plan.column)) {
+        columnPageData.set(plan.column, [])
+      }
+      columnPageData.get(plan.column).push({
+        buffer,
+        pageIdx: plan.pageIdx,
+        location: plan.location,
+      })
+    }
+  }
+
+  // Combine all pages into complete column data
+  for (const { column, columnName, indices } of pageReadColumns) {
+    if (!columnPageData.has(column)) continue
+
+    const pages = columnPageData.get(column)
+    const dictionary = columnDictionaries.get(column)
+    const schemaPath = getSchemaPath(metadata.schema, column.meta_data.path_in_schema)
+    const allValues = []
+
+    const columnDecoder = {
+      columnName: column.meta_data.path_in_schema.join('.'),
+      type: column.meta_data.type,
+      element: schemaPath[schemaPath.length - 1].element,
+      schemaPath,
+      codec: column.meta_data.codec,
+      parsers: options.parsers || DEFAULT_PARSERS,
+      compressors: options.compressors,
+      utf8: options.utf8 !== false,
+    }
+
+    for (const { buffer, pageIdx, location } of pages) {
+      // Parquet requires dictionary before data for dictionary encoding
+      let fullBuffer
+      // let readerOffset = 0
+
+      if (dictionary) {
+        // Single allocation is more efficient than multiple concatenations
+        const dictSize = dictionary.byteLength
+        const pageSize = buffer.byteLength
+        fullBuffer = new ArrayBuffer(dictSize + pageSize)
+        new Uint8Array(fullBuffer).set(new Uint8Array(dictionary), 0)
+        new Uint8Array(fullBuffer).set(new Uint8Array(buffer), dictSize)
+        // readerOffset = dictSize
+      } else {
+        fullBuffer = buffer
+      }
+
+      const reader = {
+        view: new DataView(fullBuffer),
+        offset: 0, // Always start at 0 so readColumn can parse the dictionary header
+      }
+
+      // Offset index tells us how many rows are in each page
+      const pageFirstRow = Number(location.first_row_index)
+      const nextLocation = indices.offsetIndex.page_locations[pageIdx + 1]
+      const pageRowCount = nextLocation
+        ? Number(nextLocation.first_row_index) - pageFirstRow
+        : Number(column.meta_data.num_values) - pageFirstRow
+
+      // Read this specific page's data
+      const pageValues = readColumn(
+        reader,
+        {
+          groupStart: 0,
+          selectStart: 0,
+          selectEnd: pageRowCount,
+          groupRows: pageRowCount,
+        },
+        columnDecoder
+      )
+
+      // readColumn may return multiple chunks that need flattening
+
+      if (Array.isArray(pageValues)) {
+        for (const chunk of pageValues) {
+          if (Array.isArray(chunk)) {
+            // concat handles typed arrays efficiently
+            if (chunk.slice && typeof chunk.slice === 'function' && chunk.constructor !== Array) {
+              concat(allValues, chunk)
+            } else {
+              allValues.push(...chunk)
+            }
+          } else {
+            // Single values just get pushed
+            allValues.push(chunk)
+          }
+        }
+      } else {
+        // Non-array means single value
+        allValues.push(pageValues)
+      }
+    }
+
+    columnData.set(columnName, allValues)
+  }
+
+  return columnData
+}
+
+/**
+ * Read entire row group without filtering
+ * @param {AsyncBuffer} file
+ * @param {FileMetaData} metadata
+ * @param {number} rgIndex
+ * @param {string[]} columns
+ * @param {object} options
+ * @param {number} groupStart
+ * @returns {Promise<object[]>}
+ */
+async function readRowGroup(file, metadata, rgIndex, columns, options, groupStart) {
+  const rowGroup = metadata.row_groups[rgIndex]
+  const groupEnd = groupStart + Number(rowGroup.num_rows)
+
+  return await parquetReadObjects({
+    file,
+    metadata,
+    columns,
+    rowStart: groupStart,
+    rowEnd: groupEnd,
+    ...options,
   })
 }
 
 /**
- * Returns an array of column names that are needed to evaluate the mongo filter.
- *
- * @param {ParquetQueryFilter} [filter]
+ * Assemble column data into rows
+ * @param {Map<string, any[]>} columnData
+ * @param {string[]} columns
+ * @returns {object[]}
+ */
+function assembleRows(columnData, columns) {
+  if (columnData.size === 0) return []
+
+  const numRows = Math.max(...[...columnData.values()].map((d) => d.length))
+  const rows = []
+
+  for (let i = 0; i < numRows; i++) {
+    const row = {}
+    for (const col of columns) {
+      const data = columnData.get(col)
+      if (data && Array.isArray(data)) {
+        row[col] = data[i] !== undefined ? data[i] : null
+      } else {
+        row[col] = null
+      }
+    }
+    rows.push(row)
+  }
+
+  return rows
+}
+
+/**
+ * Create column name to index mapping for a row group
+ * @param {object} rowGroup
+ * @returns {Map<string, number>}
+ */
+function createColumnIndexMap(rowGroup) {
+  const map = new Map()
+  rowGroup.columns.forEach((column, index) => {
+    if (column.meta_data?.path_in_schema) {
+      // Only map top-level column names for now
+      if (column.meta_data.path_in_schema.length > 0) {
+        map.set(column.meta_data.path_in_schema[0], index)
+      }
+    }
+  })
+  return map
+}
+
+/**
+ * Create predicates from MongoDB-style filter
+ * @param {object} filter
+ * @returns {Map<string, Function>}
+ */
+function createPredicates(filter) {
+  const predicates = new Map()
+
+  function addPredicate(column, condition) {
+    const pred = createRangePredicate(condition)
+    if (pred) {
+      predicates.set(column, pred)
+    }
+  }
+
+  function processFilter(f) {
+    if (f.$and) {
+      f.$and.forEach(processFilter)
+    } else if (f.$or) {
+      // OR predicates across different columns can't use statistics effectively
+    } else {
+      // Process column-level conditions
+      for (const [col, cond] of Object.entries(f)) {
+        if (!col.startsWith('$')) {
+          addPredicate(col, cond)
+        }
+      }
+    }
+  }
+
+  processFilter(filter)
+  return predicates
+}
+
+/**
+ * Create range predicate from condition
+ * @param {any} condition
+ * @returns {Function|null}
+ */
+function createRangePredicate(condition) {
+  // Handle direct value comparison
+  if (typeof condition !== 'object' || condition === null) {
+    return (min, max) => min <= condition && condition <= max
+  }
+
+  const { $eq, $gt, $gte, $lt, $lte, $in } = condition
+
+  // Create a function that checks if a [min,max] range could contain values
+  // that satisfy the condition. Used for row group and page filtering.
+  return (min, max) => {
+    if ($eq !== undefined) {
+      return min <= $eq && $eq <= max
+    }
+
+    if ($in && Array.isArray($in)) {
+      return $in.some((v) => min <= v && v <= max)
+    }
+
+    let possible = true
+
+    if ($gt !== undefined) {
+      possible = possible && max > $gt
+    }
+    if ($gte !== undefined) {
+      possible = possible && max >= $gte
+    }
+    if ($lt !== undefined) {
+      possible = possible && min < $lt
+    }
+    if ($lte !== undefined) {
+      possible = possible && min <= $lte
+    }
+
+    return possible
+  }
+}
+
+/**
+ * Check if row matches filter exactly
+ * @param {object} row
+ * @param {object} filter
+ * @returns {boolean}
+ */
+function matchesFilter(row, filter) {
+  if (filter.$and) {
+    return filter.$and.every((f) => matchesFilter(row, f))
+  }
+
+  if (filter.$or) {
+    return filter.$or.some((f) => matchesFilter(row, f))
+  }
+
+  if (filter.$nor) {
+    return !filter.$nor.some((f) => matchesFilter(row, f))
+  }
+
+  if (filter.$not) {
+    return !matchesFilter(row, filter.$not)
+  }
+
+  // Evaluate each column's condition
+  for (const [col, cond] of Object.entries(filter)) {
+    if (col.startsWith('$')) continue
+
+    const value = row[col]
+    const matches = matchesCondition(value, cond)
+    if (!matches) {
+      return false
+    }
+  }
+
+  return true
+}
+
+/**
+ * Check if value matches condition
+ * @param {any} value
+ * @param {any} condition
+ * @returns {boolean}
+ */
+function matchesCondition(value, condition) {
+  // Handle direct value comparison (including arrays)
+  if (typeof condition !== 'object' || condition === null || Array.isArray(condition)) {
+    return equals(value, condition)
+  }
+
+  // MongoDB semantics: all operators on a field must be satisfied
+  for (const [op, target] of Object.entries(condition)) {
+    switch (op) {
+    case '$eq':
+      if (!equals(value, target)) return false
+      break
+    case '$ne':
+      if (equals(value, target)) return false
+      break
+    case '$gt':
+      if (!(value > target)) return false
+      break
+    case '$gte':
+      if (!(value >= target)) return false
+      break
+    case '$lt':
+      if (!(value < target)) return false
+      break
+    case '$lte':
+      if (!(value <= target)) return false
+      break
+    case '$in':
+      if (!Array.isArray(target) || !target.includes(value)) return false
+      break
+    case '$nin':
+      if (!Array.isArray(target) || target.includes(value)) return false
+      break
+    case '$not':
+      // $not inverts the entire condition
+      if (matchesCondition(value, target)) return false
+      break
+    }
+  }
+
+  return true
+}
+
+/**
+ * Sort rows by column
+ * @param {object[]} rows
+ * @param {string} orderBy
+ * @param {boolean} desc
+ * @returns {object[]}
+ */
+function sortRows(rows, orderBy, desc) {
+  return [...rows].sort((a, b) => {
+    const aVal = a[orderBy]
+    const bVal = b[orderBy]
+
+    if (aVal === bVal) {
+      // Use __index__ to ensure stable sorting
+      if (a.__index__ !== undefined && b.__index__ !== undefined) {
+        return a.__index__ - b.__index__
+      }
+      return 0
+    }
+    if (aVal === null || aVal === undefined) return desc ? -1 : 1
+    if (bVal === null || bVal === undefined) return desc ? 1 : -1
+
+    const cmp = aVal < bVal ? -1 : 1
+    return desc ? -cmp : cmp
+  })
+}
+
+/**
+ * Project row to selected columns
+ * @param {object} row
+ * @param {string[]} columns
+ * @returns {object}
+ */
+export function projectRow(row, columns) {
+  const projected = {}
+  for (const col of columns) {
+    projected[col] = row[col]
+  }
+  return projected
+}
+
+/**
+ * Extract column names from filter
+ * @param {object} filter
  * @returns {string[]}
  */
-function columnsNeededForFilter(filter) {
-  if (!filter) return []
-  /** @type {string[]} */
-  const columns = []
-  if ('$and' in filter && Array.isArray(filter.$and)) {
-    columns.push(...filter.$and.flatMap(columnsNeededForFilter))
-  } else if ('$or' in filter && Array.isArray(filter.$or)) {
-    columns.push(...filter.$or.flatMap(columnsNeededForFilter))
-  } else if ('$nor' in filter && Array.isArray(filter.$nor)) {
-    columns.push(...filter.$nor.flatMap(columnsNeededForFilter))
-  } else {
-    // Column filters
-    columns.push(...Object.keys(filter))
+export function extractFilterColumns(filter) {
+  const columns = new Set()
+
+  function extract(f) {
+    if (f.$and || f.$or || f.$nor) {
+      (f.$and || f.$or || f.$nor).forEach(extract)
+    } else if (f.$not) {
+      extract(f.$not)
+    } else {
+      Object.keys(f).forEach((k) => {
+        if (!k.startsWith('$')) columns.add(k)
+      })
+    }
   }
-  return columns
+
+  extract(filter)
+  return [...columns]
 }
+
+/**
+ * @import {AsyncBuffer, FileMetaData, CompressionCodec, Compressors, ParquetParsers} from './types.d.ts'
+ */

--- a/test/plan.test.js
+++ b/test/plan.test.js
@@ -1,7 +1,15 @@
 import { describe, expect, it } from 'vitest'
 import { parquetMetadataAsync } from '../src/index.js'
 import { asyncBufferFromFile } from '../src/node.js'
-import { parquetPlan } from '../src/plan.js'
+import { 
+  parquetPlan, 
+  getColumnRange, 
+  getRowGroupFullRange, 
+  createColumnIndexMap, 
+  extractFilterColumns, 
+  createPredicates, 
+  createRangePredicate 
+} from '../src/plan.js'
 
 describe('parquetPlan', () => {
   it('generates a query plan', async () => {
@@ -35,5 +43,247 @@ describe('parquetPlan', () => {
         },
       ],
     })
+  })
+})
+
+describe('getColumnRange', () => {
+  it('calculates byte range with dictionary page', () => {
+    const range = getColumnRange({
+      dictionary_page_offset: 100n,
+      data_page_offset: 200n,
+      total_compressed_size: 500n,
+    })
+    expect(range).toEqual({ startByte: 100, endByte: 600 })
+  })
+
+  it('calculates byte range without dictionary page', () => {
+    const range = getColumnRange({
+      data_page_offset: 200n,
+      total_compressed_size: 300n,
+    })
+    expect(range).toEqual({ startByte: 200, endByte: 500 })
+  })
+})
+
+describe('getRowGroupFullRange', () => {
+  it('calculates full range including indexes', () => {
+    const rowGroup = {
+      columns: [
+        {
+          meta_data: {
+            dictionary_page_offset: 100n,
+            total_compressed_size: 200n,
+          },
+          column_index_offset: 400n,
+          column_index_length: 50,
+          offset_index_offset: 500n,
+          offset_index_length: 60,
+        },
+        {
+          meta_data: {
+            data_page_offset: 300n,
+            total_compressed_size: 100n,
+          },
+        },
+      ],
+    }
+    
+    const range = getRowGroupFullRange(rowGroup)
+    expect(range).toEqual({
+      start: 100,
+      end: 560, // 500 + 60
+      size: 460,
+    })
+  })
+
+  it('handles empty row group', () => {
+    const range = getRowGroupFullRange({ columns: [] })
+    expect(range).toEqual({ start: Infinity, end: 0, size: -Infinity })
+  })
+})
+
+describe('createColumnIndexMap', () => {
+  it('creates mapping from column names to indexes', () => {
+    const rowGroup = {
+      columns: [
+        { meta_data: { path_in_schema: ['name'] } },
+        { meta_data: { path_in_schema: ['age'] } },
+        { meta_data: { path_in_schema: ['city'] } },
+      ],
+    }
+    
+    const map = createColumnIndexMap(rowGroup)
+    expect(map.get('name')).toBe(0)
+    expect(map.get('age')).toBe(1)
+    expect(map.get('city')).toBe(2)
+    expect(map.size).toBe(3)
+  })
+
+  it('skips columns without metadata', () => {
+    const rowGroup = {
+      columns: [
+        { meta_data: { path_in_schema: ['name'] } },
+        {},
+        { meta_data: { path_in_schema: [] } },
+      ],
+    }
+    
+    const map = createColumnIndexMap(rowGroup)
+    expect(map.size).toBe(1)
+    expect(map.get('name')).toBe(0)
+  })
+})
+
+describe('extractFilterColumns', () => {
+  it('extracts columns from simple filter', () => {
+    const columns = extractFilterColumns({ name: 'John', age: 30 })
+    expect(columns).toEqual(['name', 'age'])
+  })
+
+  it('extracts columns from $and filter', () => {
+    const columns = extractFilterColumns({
+      $and: [{ name: 'John' }, { age: { $gt: 25 } }],
+    })
+    expect(columns).toEqual(['name', 'age'])
+  })
+
+  it('extracts columns from $or filter', () => {
+    const columns = extractFilterColumns({
+      $or: [{ name: 'John' }, { name: 'Jane' }],
+    })
+    expect(columns).toEqual(['name'])
+  })
+
+  it('extracts columns from $nor filter', () => {
+    const columns = extractFilterColumns({
+      $nor: [{ status: 'inactive' }, { deleted: true }],
+    })
+    expect(columns).toEqual(['status', 'deleted'])
+  })
+
+  it('extracts columns from $not filter', () => {
+    const columns = extractFilterColumns({
+      $not: { age: { $lt: 18 } },
+    })
+    expect(columns).toEqual(['age'])
+  })
+
+  it('handles nested logical operators', () => {
+    const columns = extractFilterColumns({
+      $and: [
+        { $or: [{ name: 'John' }, { name: 'Jane' }] },
+        { age: { $gte: 18 } },
+      ],
+    })
+    expect(columns).toEqual(['name', 'age'])
+  })
+
+  it('ignores operator keys', () => {
+    const columns = extractFilterColumns({
+      name: { $in: ['John', 'Jane'] },
+      $comment: 'this should be ignored',
+    })
+    expect(columns).toEqual(['name'])
+  })
+})
+
+describe('createPredicates', () => {
+  it('creates predicates for simple equality', () => {
+    const predicates = createPredicates({ age: 30 })
+    expect(predicates.size).toBe(1)
+    
+    const agePred = predicates.get('age')
+    expect(agePred(25, 35)).toBe(true) // 30 is in range
+    expect(agePred(35, 40)).toBe(false) // 30 is not in range
+  })
+
+  it('creates predicates for $and conditions', () => {
+    const predicates = createPredicates({
+      $and: [{ age: { $gt: 25 } }, { age: { $lt: 35 } }],
+    })
+    expect(predicates.size).toBe(1)
+    
+    const agePred = predicates.get('age')
+    // Only the last condition for 'age' is kept, which is $lt: 35
+    expect(agePred(20, 30)).toBe(true) // min < 35
+    expect(agePred(40, 50)).toBe(false) // min not < 35
+  })
+
+  it('ignores $or conditions', () => {
+    const predicates = createPredicates({
+      $or: [{ age: 30 }, { name: 'John' }],
+    })
+    expect(predicates.size).toBe(0)
+  })
+
+  it('handles mixed conditions', () => {
+    const predicates = createPredicates({
+      age: { $gte: 18 },
+      status: 'active',
+    })
+    expect(predicates.size).toBe(2)
+  })
+})
+
+describe('createRangePredicate', () => {
+  it('handles direct value comparison', () => {
+    const pred = createRangePredicate(42)
+    expect(pred(40, 50)).toBe(true)
+    expect(pred(50, 60)).toBe(false)
+  })
+
+  it('handles $eq operator', () => {
+    const pred = createRangePredicate({ $eq: 42 })
+    expect(pred(40, 50)).toBe(true)
+    expect(pred(50, 60)).toBe(false)
+  })
+
+  it('handles $gt operator', () => {
+    const pred = createRangePredicate({ $gt: 30 })
+    expect(pred(20, 25)).toBe(false) // max not > 30
+    expect(pred(20, 35)).toBe(true) // max > 30
+    expect(pred(35, 40)).toBe(true) // all values > 30
+  })
+
+  it('handles $gte operator', () => {
+    const pred = createRangePredicate({ $gte: 30 })
+    expect(pred(20, 25)).toBe(false) // max not >= 30
+    expect(pred(20, 30)).toBe(true) // max >= 30
+    expect(pred(30, 40)).toBe(true) // all values >= 30
+  })
+
+  it('handles $lt operator', () => {
+    const pred = createRangePredicate({ $lt: 30 })
+    expect(pred(35, 40)).toBe(false) // min not < 30
+    expect(pred(25, 35)).toBe(true) // min < 30
+    expect(pred(20, 25)).toBe(true) // all values < 30
+  })
+
+  it('handles $lte operator', () => {
+    const pred = createRangePredicate({ $lte: 30 })
+    expect(pred(35, 40)).toBe(false) // min not <= 30
+    expect(pred(30, 35)).toBe(true) // min <= 30
+    expect(pred(20, 30)).toBe(true) // all values <= 30
+  })
+
+  it('handles $in operator', () => {
+    const pred = createRangePredicate({ $in: [10, 20, 30] })
+    expect(pred(5, 15)).toBe(true) // contains 10
+    expect(pred(25, 35)).toBe(true) // contains 30
+    expect(pred(35, 45)).toBe(false) // contains none
+  })
+
+  it('handles multiple operators', () => {
+    const pred = createRangePredicate({ $gte: 20, $lt: 40 })
+    expect(pred(10, 15)).toBe(false) // max < 20
+    expect(pred(15, 25)).toBe(true) // overlaps [20, 40)
+    expect(pred(35, 45)).toBe(true) // overlaps [20, 40)
+    expect(pred(45, 50)).toBe(false) // min >= 40
+  })
+
+  it('returns null for unsupported operators', () => {
+    const pred = createRangePredicate({ $ne: 42 })
+    expect(pred).toBeDefined() // still creates a predicate
+    expect(pred(40, 50)).toBe(true) // but always returns true for unsupported ops
   })
 })

--- a/test/plan.test.js
+++ b/test/plan.test.js
@@ -1,14 +1,14 @@
 import { describe, expect, it } from 'vitest'
 import { parquetMetadataAsync } from '../src/index.js'
 import { asyncBufferFromFile } from '../src/node.js'
-import { 
-  parquetPlan, 
-  getColumnRange, 
-  getRowGroupFullRange, 
-  createColumnIndexMap, 
-  extractFilterColumns, 
-  createPredicates, 
-  createRangePredicate 
+import {
+  createColumnIndexMap,
+  createPredicates,
+  createRangePredicate,
+  extractFilterColumns,
+  getColumnRange,
+  getRowGroupFullRange,
+  parquetPlan,
 } from '../src/plan.js'
 
 describe('parquetPlan', () => {
@@ -87,7 +87,7 @@ describe('getRowGroupFullRange', () => {
         },
       ],
     }
-    
+
     const range = getRowGroupFullRange(rowGroup)
     expect(range).toEqual({
       start: 100,
@@ -111,7 +111,7 @@ describe('createColumnIndexMap', () => {
         { meta_data: { path_in_schema: ['city'] } },
       ],
     }
-    
+
     const map = createColumnIndexMap(rowGroup)
     expect(map.get('name')).toBe(0)
     expect(map.get('age')).toBe(1)
@@ -127,7 +127,7 @@ describe('createColumnIndexMap', () => {
         { meta_data: { path_in_schema: [] } },
       ],
     }
-    
+
     const map = createColumnIndexMap(rowGroup)
     expect(map.size).toBe(1)
     expect(map.get('name')).toBe(0)
@@ -191,7 +191,7 @@ describe('createPredicates', () => {
   it('creates predicates for simple equality', () => {
     const predicates = createPredicates({ age: 30 })
     expect(predicates.size).toBe(1)
-    
+
     const agePred = predicates.get('age')
     expect(agePred(25, 35)).toBe(true) // 30 is in range
     expect(agePred(35, 40)).toBe(false) // 30 is not in range
@@ -202,7 +202,7 @@ describe('createPredicates', () => {
       $and: [{ age: { $gt: 25 } }, { age: { $lt: 35 } }],
     })
     expect(predicates.size).toBe(1)
-    
+
     const agePred = predicates.get('age')
     // Only the last condition for 'age' is kept, which is $lt: 35
     expect(agePred(20, 30)).toBe(true) // min < 35

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -236,7 +236,7 @@ describe('parquetQuery', () => {
 })
 
 // Import functions we want to test directly
-import { matchesFilter, matchesCondition, sortRows, projectRow, assembleRows, sliceAll } from '../src/query.js'
+import { assembleRows, matchesCondition, matchesFilter, projectRow, sliceAll, sortRows } from '../src/query.js'
 
 describe('matchesFilter', () => {
   it('matches simple equality', () => {
@@ -280,8 +280,8 @@ describe('matchesFilter', () => {
       $and: [
         { $or: [{ name: 'John' }, { name: 'Jane' }] },
         { age: { $gte: 25 } },
-        { status: 'active' }
-      ]
+        { status: 'active' },
+      ],
     }
     expect(matchesFilter(row, filter)).toBe(true)
   })
@@ -487,7 +487,7 @@ describe('sliceAll', () => {
     }
     const ranges = [[0, 10], [20, 40]]
     const result = await sliceAll(mockFile, ranges)
-    
+
     expect(mockFile.sliceAll).toHaveBeenCalledWith(ranges)
     expect(result).toHaveLength(2)
     expect(result[0].byteLength).toBe(10)
@@ -502,7 +502,7 @@ describe('sliceAll', () => {
     }
     const ranges = [[0, 10], [20, 40]]
     const result = await sliceAll(mockFile, ranges)
-    
+
     expect(mockFile.slice).toHaveBeenCalledTimes(2)
     expect(mockFile.slice).toHaveBeenCalledWith(0, 10)
     expect(mockFile.slice).toHaveBeenCalledWith(20, 40)
@@ -515,7 +515,7 @@ describe('sliceAll', () => {
     }
     const ranges = [[0, 10], null, [20, 30]]
     const result = await sliceAll(mockFile, ranges)
-    
+
     expect(mockFile.slice).toHaveBeenCalledTimes(2)
     expect(result).toHaveLength(3)
     expect(result[1].byteLength).toBe(0) // null range returns empty buffer

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -480,11 +480,14 @@ describe('assembleRows', () => {
 describe('sliceAll', () => {
   it('uses native sliceAll when available', async () => {
     const mockFile = {
+      byteLength: 1000,
+      slice: vi.fn(),
       sliceAll: vi.fn().mockResolvedValue([
         new ArrayBuffer(10),
         new ArrayBuffer(20),
       ]),
     }
+    /** @type {[number, number][]} */
     const ranges = [[0, 10], [20, 40]]
     const result = await sliceAll(mockFile, ranges)
 
@@ -496,10 +499,12 @@ describe('sliceAll', () => {
 
   it('falls back to parallel slices', async () => {
     const mockFile = {
+      byteLength: 1000,
       slice: vi.fn()
         .mockResolvedValueOnce(new ArrayBuffer(10))
         .mockResolvedValueOnce(new ArrayBuffer(20)),
     }
+    /** @type {[number, number][]} */
     const ranges = [[0, 10], [20, 40]]
     const result = await sliceAll(mockFile, ranges)
 
@@ -511,8 +516,10 @@ describe('sliceAll', () => {
 
   it('handles null ranges', async () => {
     const mockFile = {
+      byteLength: 1000,
       slice: vi.fn().mockResolvedValue(new ArrayBuffer(10)),
     }
+    /** @type {([number, number] | null)[]} */
     const ranges = [[0, 10], null, [20, 30]]
     const result = await sliceAll(mockFile, ranges)
 

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { parquetQuery } from '../src/query.js'
 import { asyncBufferFromFile } from '../src/node.js'
 import { countingBuffer } from './helpers.js'
@@ -210,7 +210,7 @@ describe('parquetQuery', () => {
     ])
     // if we weren't streaming row groups, this would be 3:
     expect(file.fetches).toBe(2) // 1 metadata, 1 row group
-    expect(file.bytes).toBe(7253) // 4099 (metadata) + 3154 (row group 0 with indices)
+    expect(file.bytes).toBe(7253) // 4099 (metadata) + 3154 (row group 0 with indexes)
   })
 
   it('filter on columns that are not selected', async () => {
@@ -232,5 +232,292 @@ describe('parquetQuery', () => {
     const file = await asyncBufferFromFile('test/files/datapage_v2.snappy.parquet')
     await expect(parquetQuery({ file, orderBy: 'nonExistent' }))
       .rejects.toThrow('parquet orderBy column not found: nonExistent')
+  })
+})
+
+// Import functions we want to test directly
+import { matchesFilter, matchesCondition, sortRows, projectRow, assembleRows, sliceAll } from '../src/query.js'
+
+describe('matchesFilter', () => {
+  it('matches simple equality', () => {
+    expect(matchesFilter({ name: 'John', age: 30 }, { name: 'John' })).toBe(true)
+    expect(matchesFilter({ name: 'Jane', age: 30 }, { name: 'John' })).toBe(false)
+  })
+
+  it('matches multiple conditions (implicit AND)', () => {
+    const row = { name: 'John', age: 30, city: 'NYC' }
+    expect(matchesFilter(row, { name: 'John', age: 30 })).toBe(true)
+    expect(matchesFilter(row, { name: 'John', age: 25 })).toBe(false)
+  })
+
+  it('matches $and conditions', () => {
+    const row = { name: 'John', age: 30 }
+    expect(matchesFilter(row, { $and: [{ name: 'John' }, { age: 30 }] })).toBe(true)
+    expect(matchesFilter(row, { $and: [{ name: 'John' }, { age: 25 }] })).toBe(false)
+  })
+
+  it('matches $or conditions', () => {
+    const row = { name: 'John', age: 30 }
+    expect(matchesFilter(row, { $or: [{ name: 'Jane' }, { age: 30 }] })).toBe(true)
+    expect(matchesFilter(row, { $or: [{ name: 'Jane' }, { age: 25 }] })).toBe(false)
+  })
+
+  it('matches $nor conditions', () => {
+    const row = { name: 'John', age: 30 }
+    expect(matchesFilter(row, { $nor: [{ name: 'Jane' }, { age: 25 }] })).toBe(true)
+    expect(matchesFilter(row, { $nor: [{ name: 'John' }, { age: 25 }] })).toBe(false)
+  })
+
+  it('matches $not conditions', () => {
+    const row = { name: 'John', age: 30 }
+    expect(matchesFilter(row, { $not: { name: 'Jane' } })).toBe(true)
+    expect(matchesFilter(row, { $not: { name: 'John' } })).toBe(false)
+  })
+
+  it('handles nested logical operators', () => {
+    const row = { name: 'John', age: 30, status: 'active' }
+    const filter = {
+      $and: [
+        { $or: [{ name: 'John' }, { name: 'Jane' }] },
+        { age: { $gte: 25 } },
+        { status: 'active' }
+      ]
+    }
+    expect(matchesFilter(row, filter)).toBe(true)
+  })
+
+  it('ignores $ prefixed keys at top level', () => {
+    const row = { name: 'John' }
+    expect(matchesFilter(row, { name: 'John', $comment: 'ignored' })).toBe(true)
+  })
+})
+
+describe('matchesCondition', () => {
+  it('matches direct value equality', () => {
+    expect(matchesCondition('John', 'John')).toBe(true)
+    expect(matchesCondition(30, 30)).toBe(true)
+    expect(matchesCondition(true, true)).toBe(true)
+    expect(matchesCondition('John', 'Jane')).toBe(false)
+  })
+
+  it('matches null values', () => {
+    expect(matchesCondition(null, null)).toBe(true)
+    expect(matchesCondition(undefined, null)).toBe(false) // undefined !== null
+    expect(matchesCondition('value', null)).toBe(false)
+  })
+
+  it('matches arrays', () => {
+    expect(matchesCondition([1, 2, 3], [1, 2, 3])).toBe(true)
+    expect(matchesCondition([1, 2, 3], [3, 2, 1])).toBe(false)
+  })
+
+  it('matches $eq operator', () => {
+    expect(matchesCondition(42, { $eq: 42 })).toBe(true)
+    expect(matchesCondition(42, { $eq: 43 })).toBe(false)
+  })
+
+  it('matches $ne operator', () => {
+    expect(matchesCondition(42, { $ne: 43 })).toBe(true)
+    expect(matchesCondition(42, { $ne: 42 })).toBe(false)
+  })
+
+  it('matches $gt operator', () => {
+    expect(matchesCondition(42, { $gt: 40 })).toBe(true)
+    expect(matchesCondition(42, { $gt: 42 })).toBe(false)
+    expect(matchesCondition(42, { $gt: 45 })).toBe(false)
+  })
+
+  it('matches $gte operator', () => {
+    expect(matchesCondition(42, { $gte: 40 })).toBe(true)
+    expect(matchesCondition(42, { $gte: 42 })).toBe(true)
+    expect(matchesCondition(42, { $gte: 45 })).toBe(false)
+  })
+
+  it('matches $lt operator', () => {
+    expect(matchesCondition(42, { $lt: 45 })).toBe(true)
+    expect(matchesCondition(42, { $lt: 42 })).toBe(false)
+    expect(matchesCondition(42, { $lt: 40 })).toBe(false)
+  })
+
+  it('matches $lte operator', () => {
+    expect(matchesCondition(42, { $lte: 45 })).toBe(true)
+    expect(matchesCondition(42, { $lte: 42 })).toBe(true)
+    expect(matchesCondition(42, { $lte: 40 })).toBe(false)
+  })
+
+  it('matches $in operator', () => {
+    expect(matchesCondition('apple', { $in: ['apple', 'banana'] })).toBe(true)
+    expect(matchesCondition('cherry', { $in: ['apple', 'banana'] })).toBe(false)
+    expect(matchesCondition(42, { $in: [40, 42, 44] })).toBe(true)
+  })
+
+  it('matches $nin operator', () => {
+    expect(matchesCondition('cherry', { $nin: ['apple', 'banana'] })).toBe(true)
+    expect(matchesCondition('apple', { $nin: ['apple', 'banana'] })).toBe(false)
+  })
+
+  it('matches $not operator', () => {
+    expect(matchesCondition(42, { $not: { $gt: 50 } })).toBe(true)
+    expect(matchesCondition(42, { $not: { $lt: 50 } })).toBe(false)
+  })
+
+  it('matches multiple operators (all must be true)', () => {
+    expect(matchesCondition(42, { $gte: 40, $lte: 45 })).toBe(true)
+    expect(matchesCondition(42, { $gte: 40, $lt: 42 })).toBe(false)
+  })
+})
+
+describe('sortRows', () => {
+  it('sorts rows by column ascending', () => {
+    const rows = [
+      { name: 'Charlie', age: 30 },
+      { name: 'Alice', age: 25 },
+      { name: 'Bob', age: 35 },
+    ]
+    sortRows(rows, 'name', false)
+    expect(rows.map(r => r.name)).toEqual(['Alice', 'Bob', 'Charlie'])
+  })
+
+  it('sorts rows by column descending', () => {
+    const rows = [
+      { name: 'Charlie', age: 30 },
+      { name: 'Alice', age: 25 },
+      { name: 'Bob', age: 35 },
+    ]
+    sortRows(rows, 'age', true)
+    expect(rows.map(r => r.age)).toEqual([35, 30, 25])
+  })
+
+  it('handles null values', () => {
+    const rows = [
+      { name: 'Charlie', age: 30 },
+      { name: null, age: 25 },
+      { name: 'Bob', age: 35 },
+      { name: undefined, age: 40 },
+    ]
+    sortRows(rows, 'name', false)
+    // nulls go to end when ascending
+    expect(rows.map(r => r.name)).toEqual(['Bob', 'Charlie', null, undefined])
+  })
+
+  it('maintains stable sort with __index__', () => {
+    const rows = [
+      { name: 'Alice', age: 30, __index__: 0 },
+      { name: 'Bob', age: 30, __index__: 1 },
+      { name: 'Charlie', age: 30, __index__: 2 },
+    ]
+    sortRows(rows, 'age', false)
+    // Same age values maintain original order
+    expect(rows.map(r => r.name)).toEqual(['Alice', 'Bob', 'Charlie'])
+  })
+})
+
+describe('projectRow', () => {
+  it('projects selected columns', () => {
+    const row = { name: 'John', age: 30, city: 'NYC', country: 'USA' }
+    const projected = projectRow(row, ['name', 'age'])
+    expect(projected).toEqual({ name: 'John', age: 30 })
+  })
+
+  it('handles missing columns', () => {
+    const row = { name: 'John', age: 30 }
+    const projected = projectRow(row, ['name', 'city'])
+    expect(projected).toEqual({ name: 'John', city: undefined })
+  })
+
+  it('preserves column order', () => {
+    const row = { z: 3, y: 2, x: 1 }
+    const projected = projectRow(row, ['x', 'y', 'z'])
+    expect(Object.keys(projected)).toEqual(['x', 'y', 'z'])
+  })
+})
+
+describe('assembleRows', () => {
+  it('assembles column data into rows', () => {
+    const columnData = new Map([
+      ['name', ['Alice', 'Bob', 'Charlie']],
+      ['age', [25, 30, 35]],
+    ])
+    const rows = assembleRows(columnData, ['name', 'age'])
+    expect(rows).toEqual([
+      { name: 'Alice', age: 25 },
+      { name: 'Bob', age: 30 },
+      { name: 'Charlie', age: 35 },
+    ])
+  })
+
+  it('handles missing columns', () => {
+    const columnData = new Map([
+      ['name', ['Alice', 'Bob']],
+    ])
+    const rows = assembleRows(columnData, ['name', 'age'])
+    expect(rows).toEqual([
+      { name: 'Alice', age: null },
+      { name: 'Bob', age: null },
+    ])
+  })
+
+  it('handles uneven column lengths', () => {
+    const columnData = new Map([
+      ['name', ['Alice', 'Bob', 'Charlie']],
+      ['age', [25, 30]], // shorter
+    ])
+    const rows = assembleRows(columnData, ['name', 'age'])
+    expect(rows).toEqual([
+      { name: 'Alice', age: 25 },
+      { name: 'Bob', age: 30 },
+      { name: 'Charlie', age: null },
+    ])
+  })
+
+  it('returns empty array for empty data', () => {
+    const columnData = new Map()
+    const rows = assembleRows(columnData, ['name', 'age'])
+    expect(rows).toEqual([])
+  })
+})
+
+describe('sliceAll', () => {
+  it('uses native sliceAll when available', async () => {
+    const mockFile = {
+      sliceAll: vi.fn().mockResolvedValue([
+        new ArrayBuffer(10),
+        new ArrayBuffer(20),
+      ]),
+    }
+    const ranges = [[0, 10], [20, 40]]
+    const result = await sliceAll(mockFile, ranges)
+    
+    expect(mockFile.sliceAll).toHaveBeenCalledWith(ranges)
+    expect(result).toHaveLength(2)
+    expect(result[0].byteLength).toBe(10)
+    expect(result[1].byteLength).toBe(20)
+  })
+
+  it('falls back to parallel slices', async () => {
+    const mockFile = {
+      slice: vi.fn()
+        .mockResolvedValueOnce(new ArrayBuffer(10))
+        .mockResolvedValueOnce(new ArrayBuffer(20)),
+    }
+    const ranges = [[0, 10], [20, 40]]
+    const result = await sliceAll(mockFile, ranges)
+    
+    expect(mockFile.slice).toHaveBeenCalledTimes(2)
+    expect(mockFile.slice).toHaveBeenCalledWith(0, 10)
+    expect(mockFile.slice).toHaveBeenCalledWith(20, 40)
+    expect(result).toHaveLength(2)
+  })
+
+  it('handles null ranges', async () => {
+    const mockFile = {
+      slice: vi.fn().mockResolvedValue(new ArrayBuffer(10)),
+    }
+    const ranges = [[0, 10], null, [20, 30]]
+    const result = await sliceAll(mockFile, ranges)
+    
+    expect(mockFile.slice).toHaveBeenCalledTimes(2)
+    expect(result).toHaveLength(3)
+    expect(result[1].byteLength).toBe(0) // null range returns empty buffer
   })
 })

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -210,7 +210,7 @@ describe('parquetQuery', () => {
     ])
     // if we weren't streaming row groups, this would be 3:
     expect(file.fetches).toBe(2) // 1 metadata, 1 row group
-    expect(file.bytes).toBe(5261)
+    expect(file.bytes).toBe(7253) // 4099 (metadata) + 3154 (row group 0 with indices)
   })
 
   it('filter on columns that are not selected', async () => {


### PR DESCRIPTION
This is just a preliminary pull request that implements most of what we talked about last(!) year. Predicate pushdown has been implemented in plan.js and query.js. Here's a summary of the additions:

In plan.js, we have more utilities for query planning, which we use to construct predicates that are used in query.js. We use row group and page-level statistics here to skip chunks that don't match the predicates. I added some utilities in column.js for reading pages.