### PR TITLE
export type ParquetQueryFilter

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -62,4 +62,5 @@ export function parquetReadObjects(options) {
  * @typedef {import('../src/types.d.ts').ParquetReadOptions} ParquetReadOptions
  * @typedef {import('../src/types.d.ts').MetadataOptions} MetadataOptions
  * @typedef {import('../src/types.d.ts').ParquetParsers} ParquetParsers
+ * @typedef {import('../src/types.d.ts').ParquetQueryFilter} ParquetQueryFilter
  */


### PR DESCRIPTION
To avoid:

```
import { parquetQuery } from 'hyparquet'
type ParquetQueryFilter = Exclude<Parameters<typeof parquetQuery>[0]['filter'], undefined>
```

when a client requires this type