### PR TITLE
Remove a circular dependency

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,27 +1,8 @@
-import { parquetRead } from './read.js'
-
 export { parquetMetadata, parquetMetadataAsync, parquetSchema } from './metadata.js'
-export { parquetRead }
+export { parquetRead, parquetReadObjects } from './read.js'
 export { parquetQuery } from './query.js'
 export { snappyUncompress } from './snappy.js'
 export { asyncBufferFromUrl, byteLengthFromUrl, cachedAsyncBuffer, flatten, toJson } from './utils.js'
-
-/**
- * This is a helper function to read parquet row data as a promise.
- * It is a wrapper around the more configurable parquetRead function.
- *
- * @param {Omit<ParquetReadOptions, 'onComplete'>} options
- * @returns {Promise<Record<string, any>[]>} resolves when all requested rows and columns are parsed
-*/
-export function parquetReadObjects(options) {
-  return new Promise((onComplete, reject) => {
-    parquetRead({
-      rowFormat: 'object',
-      ...options,
-      onComplete,
-    }).catch(reject)
-  })
-}
 
 /**
  * Explicitly export types for use in downstream typescript projects through

--- a/src/read.js
+++ b/src/read.js
@@ -4,7 +4,7 @@ import { assembleAsync, asyncGroupToRows, readRowGroup } from './rowgroup.js'
 import { concat, flatten } from './utils.js'
 
 /**
- * @import {AsyncBuffer, AsyncRowGroup, DecodedArray, FileMetaData, ParquetReadOptions} from '../src/types.js'
+ * @import {AsyncRowGroup, DecodedArray, ParquetReadOptions} from '../src/types.js'
  */
 /**
  * Read parquet data rows from a file-like object.
@@ -23,7 +23,7 @@ export async function parquetRead(options) {
   options.metadata ??= await parquetMetadataAsync(options.file)
 
   // read row groups
-  const asyncGroups = await parquetReadAsync(options)
+  const asyncGroups = parquetReadAsync(options)
 
   const { rowStart = 0, rowEnd, columns, onChunk, onComplete, rowFormat } = options
 
@@ -119,4 +119,21 @@ export async function parquetReadColumn(options) {
     columnData.push(flatten(await rg.asyncColumns[0].data))
   }
   return flatten(columnData)
+}
+
+/**
+ * This is a helper function to read parquet row data as a promise.
+ * It is a wrapper around the more configurable parquetRead function.
+ *
+ * @param {Omit<ParquetReadOptions, 'onComplete'>} options
+ * @returns {Promise<Record<string, any>[]>} resolves when all requested rows and columns are parsed
+*/
+export function parquetReadObjects(options) {
+  return new Promise((onComplete, reject) => {
+    parquetRead({
+      rowFormat: 'object',
+      ...options,
+      onComplete,
+    }).catch(reject)
+  })
 }


### PR DESCRIPTION
Also: removed two unused types in import, and removed a useless await keyword.

---

The circular dependency was reported when building geoparquet:

```shell
git clone git@github.com:hyparam/geoparquet.git
cd geoparquet
npm I
npm run build
```

```
> geoparquet@0.3.0 build
> rollup -c


demo/demo.js → demo/bundle.min.js...
(!) Circular dependency
node_modules/hyparquet/src/index.js -> node_modules/hyparquet/src/query.js -> node_modules/hyparquet/src/index.js
created demo/bundle.min.js in 276ms
```