### PR TITLE
Fix early page termination for non-flat columns

### DIFF
--- a/src/column.js
+++ b/src/column.js
@@ -16,7 +16,8 @@ import { deserializeTCompactProtocol } from './thrift.js'
  * @returns {DecodedArray[]}
  */
 export function readColumn(reader, { groupStart, selectStart, selectEnd }, columnDecoder, onPage) {
-  const { columnName } = columnDecoder
+  const { columnName, schemaPath } = columnDecoder
+  const isFlat = isFlatColumn(schemaPath)
   /** @type {DecodedArray[]} */
   const chunks = []
   /** @type {DecodedArray | undefined} */
@@ -34,7 +35,7 @@ export function readColumn(reader, { groupStart, selectStart, selectEnd }, colum
     })
   })
 
-  while (rowCount < selectEnd) {
+  while (isFlat ? rowCount < selectEnd : reader.offset < reader.view.byteLength - 1) {
     if (reader.offset >= reader.view.byteLength - 1) break // end of reader
 
     // read page header


### PR DESCRIPTION
There was a struct parsing error when trying to load a dataset from huggingface:

https://huggingface.co/datasets/Lakshan2003/customer_service_200k_client_agent_conversations/blob/main/data/train-00000-of-00001.parquet

What was happening was that we were stopping page reading early, because although we had 1000 values, those were going to be converted to a list, and actually there was another page after that we should have been reading.

This PR fixes by only applying the early stopping criteria when a column is known to be "flat".
