### PR TITLE
try to fix the types again

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -45,7 +45,4 @@ export { asyncBufferFromUrl, byteLengthFromUrl, cachedAsyncBuffer, flatten, toJs
  * @typedef {import('../src/types.d.ts').MetadataOptions} MetadataOptions
  * @typedef {import('../src/types.d.ts').ParquetParsers} ParquetParsers
  * @typedef {import('../src/types.d.ts').ParquetQueryFilter} ParquetQueryFilter
- * @typedef {import('../src/types.d.ts').ArrayRowFormat} ArrayRowFormat
- * @typedef {import('../src/types.d.ts').ObjectRowFormat} ObjectRowFormat
- * @typedef {import('../src/types.d.ts').BaseParquetReadOptions} BaseParquetReadOptions
  */

--- a/src/index.js
+++ b/src/index.js
@@ -45,4 +45,7 @@ export { asyncBufferFromUrl, byteLengthFromUrl, cachedAsyncBuffer, flatten, toJs
  * @typedef {import('../src/types.d.ts').MetadataOptions} MetadataOptions
  * @typedef {import('../src/types.d.ts').ParquetParsers} ParquetParsers
  * @typedef {import('../src/types.d.ts').ParquetQueryFilter} ParquetQueryFilter
+ * @typedef {import('../src/types.d.ts').ArrayRowFormat} ArrayRowFormat
+ * @typedef {import('../src/types.d.ts').ObjectRowFormat} ObjectRowFormat
+ * @typedef {import('../src/types.d.ts').BaseParquetReadOptions} BaseParquetReadOptions
  */

--- a/src/query.js
+++ b/src/query.js
@@ -105,7 +105,8 @@ export async function parquetQuery(options) {
       .slice(rowStart, rowEnd)
 
     const sparseData = await parquetReadRows({ ...options, rows: sortedIndices })
-    // TODO(SL): add the __index__ field in the return type?
+    // warning: the type Record<string, any> & {__index__: number})[] is simplified into Record<string, any>[]
+    // when returning. The data contains the __index__ property, but it's not exposed as such.
     const data = sortedIndices.map(index => sparseData[index])
     return data
   } else {
@@ -161,7 +162,8 @@ async function parquetReadRows(options) {
     // TODO: fetch in parallel
     const groupData = await parquetReadObjects({ ...options, rowStart: rangeStart, rowEnd: rangeEnd })
     for (let i = rangeStart; i < rangeEnd; i++) {
-      sparseData[i] = Object.assign(groupData[i - rangeStart], { __index__: i })
+      // warning: if the row contains a column named __index__, it will overwrite the index.
+      sparseData[i] = { __index__: i, ...groupData[i - rangeStart] }
     }
   }
   return sparseData

--- a/src/query.js
+++ b/src/query.js
@@ -162,9 +162,8 @@ async function parquetReadRows(options) {
     // TODO: fetch in parallel
     const groupData = await parquetReadObjects({ ...options, rowStart: rangeStart, rowEnd: rangeEnd })
     for (let i = rangeStart; i < rangeEnd; i++) {
-      // warning: the index will overwrite a column named __index__ if it existed in the original data.
-      // TODO: should we throw an error instead?
-      sparseData[i] = { ...groupData[i - rangeStart], __index__: i }
+      // warning: if the row contains a column named __index__, it will overwrite the index.
+      sparseData[i] = { __index__: i, ...groupData[i - rangeStart] }
     }
   }
   return sparseData

--- a/src/query.js
+++ b/src/query.js
@@ -162,8 +162,9 @@ async function parquetReadRows(options) {
     // TODO: fetch in parallel
     const groupData = await parquetReadObjects({ ...options, rowStart: rangeStart, rowEnd: rangeEnd })
     for (let i = rangeStart; i < rangeEnd; i++) {
-      // warning: if the row contains a column named __index__, it will overwrite the index.
-      sparseData[i] = { __index__: i, ...groupData[i - rangeStart] }
+      // warning: the index will overwrite a column named __index__ if it existed in the original data.
+      // TODO: should we throw an error instead?
+      sparseData[i] = { ...groupData[i - rangeStart], __index__: i }
     }
   }
   return sparseData

--- a/src/query.js
+++ b/src/query.js
@@ -5,7 +5,6 @@ import { equals } from './utils.js'
 /**
  * @import {ParquetQueryFilter, BaseParquetReadOptions} from '../src/types.js'
  */
-
 /**
  * Wraps parquetRead with filter and orderBy support.
  * This is a parquet-aware query engine that can read a subset of rows and columns.

--- a/src/read.js
+++ b/src/read.js
@@ -70,7 +70,7 @@ export async function parquetRead(options) {
         const selectEnd = Math.min((rowEnd ?? Infinity) - asyncGroup.groupStart, asyncGroup.groupRows)
         // transpose column chunks to rows in output
         const groupData = await asyncGroupToRows(asyncGroup, selectStart, selectEnd, columns, rowFormat)
-        concat(rows, groupData.slice(selectStart, selectEnd))
+        concat(rows, groupData)
       }
       onComplete(rows)
     } else {
@@ -82,7 +82,7 @@ export async function parquetRead(options) {
         const selectEnd = Math.min((rowEnd ?? Infinity) - asyncGroup.groupStart, asyncGroup.groupRows)
         // transpose column chunks to rows in output
         const groupData = await asyncGroupToRows(asyncGroup, selectStart, selectEnd, columns, rowFormat)
-        concat(rows, groupData.slice(selectStart, selectEnd))
+        concat(rows, groupData)
       }
       onComplete(rows)
     }

--- a/src/read.js
+++ b/src/read.js
@@ -4,7 +4,7 @@ import { assembleAsync, asyncGroupToRows, readRowGroup } from './rowgroup.js'
 import { concat, flatten } from './utils.js'
 
 /**
- * @import {AsyncRowGroup, DecodedArray, ParquetReadOptions, BaseParquetReadOptions, ArrayRowFormat, ObjectRowFormat} from '../src/types.js'
+ * @import {AsyncRowGroup, DecodedArray, ParquetReadOptions, BaseParquetReadOptions} from '../src/types.js'
  */
 
 /**
@@ -114,7 +114,7 @@ export function parquetReadAsync(options) {
 /**
  * Reads a single column from a parquet file.
  *
- * @param {ParquetReadOptions} options
+ * @param {BaseParquetReadOptions} options
  * @returns {Promise<DecodedArray>}
  */
 export async function parquetReadColumn(options) {
@@ -137,27 +137,17 @@ export async function parquetReadColumn(options) {
 }
 
 /**
- * @overload
- * @param {Omit<BaseParquetReadOptions & ObjectRowFormat, 'onComplete'>} options
- * @returns {Promise<Record<string, any>[]>} resolves when all requested rows and columns are parsed
- */
-/**
- * @overload
- * @param {Omit<BaseParquetReadOptions & ArrayRowFormat, 'onComplete'>} options
- * @returns {Promise<any[][]>} resolves when all requested rows and columns are parsed
-*/
-/**
  * This is a helper function to read parquet row data as a promise.
  * It is a wrapper around the more configurable parquetRead function.
  *
  * @param {Omit<ParquetReadOptions, 'onComplete'>} options
- * @returns {Promise<Record<string, any>[] | any[][]>} resolves when all requested rows and columns are parsed
+ * @returns {Promise<Record<string, any>[]>} resolves when all requested rows and columns are parsed
  */
 export function parquetReadObjects(options) {
   return new Promise((onComplete, reject) => {
     parquetRead({
-      rowFormat: 'object',
       ...options,
+      rowFormat: 'object', // force object output
       onComplete,
     }).catch(reject)
   })

--- a/src/read.js
+++ b/src/read.js
@@ -6,7 +6,6 @@ import { concat, flatten } from './utils.js'
 /**
  * @import {AsyncRowGroup, DecodedArray, ParquetReadOptions, BaseParquetReadOptions} from '../src/types.js'
  */
-
 /**
  * Read parquet data rows from a file-like object.
  * Reads the minimal number of row groups and columns to satisfy the request.

--- a/src/rowgroup.js
+++ b/src/rowgroup.js
@@ -112,24 +112,27 @@ export async function asyncGroupToRows({ asyncColumns }, selectStart, selectEnd,
   const columnIndexes = columnOrder.map(name => asyncColumns.findIndex(column => column.pathInSchema[0] === name))
 
   // transpose columns into rows
+  const selectCount = selectEnd - selectStart
   if (rowFormat === 'object') {
     /** @type {Record<string, any>[]} */
-    const groupData = new Array(selectEnd)
-    for (let row = selectStart; row < selectEnd; row++) {
+    const groupData = new Array(selectCount)
+    for (let selectRow = 0; selectRow < selectCount; selectRow++) {
+      const row = selectStart + selectRow
       // return each row as an object
       /** @type {Record<string, any>} */
       const rowData = {}
       for (let i = 0; i < asyncColumns.length; i++) {
         rowData[asyncColumns[i].pathInSchema[0]] = columnDatas[i][row]
       }
-      groupData[row] = rowData
+      groupData[selectRow] = rowData
     }
     return groupData
   }
 
   /** @type {any[][]} */
-  const groupData = new Array(selectEnd)
-  for (let row = selectStart; row < selectEnd; row++) {
+  const groupData = new Array(selectCount)
+  for (let selectRow = 0; selectRow < selectCount; selectRow++) {
+    const row = selectStart + selectRow
     // return each row as an array
     const rowData = new Array(asyncColumns.length)
     for (let i = 0; i < columnOrder.length; i++) {
@@ -137,7 +140,7 @@ export async function asyncGroupToRows({ asyncColumns }, selectStart, selectEnd,
         rowData[i] = columnDatas[columnIndexes[i]][row]
       }
     }
-    groupData[row] = rowData
+    groupData[selectRow] = rowData
   }
   return groupData
 }

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -15,11 +15,11 @@ export interface MetadataOptions {
   parsers?: ParquetParsers // custom parsers to decode advanced types
 }
 
-export interface ArrayRowFormat {
+interface ArrayRowFormat {
   rowFormat?: 'array' // format of each row passed to the onComplete function. Can be omitted, as it's the default.
   onComplete?: (rows: any[][]) => void // called when all requested rows and columns are parsed
 }
-export interface ObjectRowFormat {
+interface ObjectRowFormat {
   rowFormat: 'object' // format of each row passed to the onComplete function
   onComplete?: (rows: Record<string, any>[]) => void // called when all requested rows and columns are parsed
 }

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -15,23 +15,32 @@ export interface MetadataOptions {
   parsers?: ParquetParsers // custom parsers to decode advanced types
 }
 
+export interface ArrayRowFormat {
+  rowFormat?: 'array' // format of each row passed to the onComplete function. Can be omitted, as it's the default.
+  onComplete?: (rows: any[][]) => void // called when all requested rows and columns are parsed
+}
+export interface ObjectRowFormat {
+  rowFormat: 'object' // format of each row passed to the onComplete function
+  onComplete?: (rows: Record<string, any>[]) => void // called when all requested rows and columns are parsed
+}
+
 /**
  * Parquet query options for reading data
  */
-export interface ParquetReadOptions {
+export interface BaseParquetReadOptions {
   file: AsyncBuffer // file-like object containing parquet data
   metadata?: FileMetaData // parquet metadata, will be parsed if not provided
   columns?: string[] // columns to read, all columns if undefined
-  rowFormat?: 'object' | 'array' // format of each row passed to the onComplete function
   rowStart?: number // first requested row index (inclusive)
   rowEnd?: number // last requested row index (exclusive)
   onChunk?: (chunk: ColumnData) => void // called when a column chunk is parsed. chunks may contain data outside the requested range.
   onPage?: (chunk: ColumnData) => void // called when a data page is parsed. pages may contain data outside the requested range.
-  onComplete?: (rows: any[][]) => void // called when all requested rows and columns are parsed
   compressors?: Compressors // custom decompressors
   utf8?: boolean // decode byte arrays as utf8 strings (default true)
   parsers?: ParquetParsers // custom parsers to decode advanced types
 }
+
+export type ParquetReadOptions = BaseParquetReadOptions & (ArrayRowFormat | ObjectRowFormat)
 
 /**
  * Parquet query options for filtering data

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -15,15 +15,6 @@ export interface MetadataOptions {
   parsers?: ParquetParsers // custom parsers to decode advanced types
 }
 
-interface ArrayRowFormat {
-  rowFormat?: 'array' // format of each row passed to the onComplete function. Can be omitted, as it's the default.
-  onComplete?: (rows: any[][]) => void // called when all requested rows and columns are parsed
-}
-interface ObjectRowFormat {
-  rowFormat: 'object' // format of each row passed to the onComplete function
-  onComplete?: (rows: Record<string, any>[]) => void // called when all requested rows and columns are parsed
-}
-
 /**
  * Parquet query options for reading data
  */
@@ -40,6 +31,14 @@ export interface BaseParquetReadOptions {
   parsers?: ParquetParsers // custom parsers to decode advanced types
 }
 
+interface ArrayRowFormat {
+  rowFormat?: 'array' // format of each row passed to the onComplete function. Can be omitted, as it's the default.
+  onComplete?: (rows: any[][]) => void // called when all requested rows and columns are parsed
+}
+interface ObjectRowFormat {
+  rowFormat: 'object' // format of each row passed to the onComplete function
+  onComplete?: (rows: Record<string, any>[]) => void // called when all requested rows and columns are parsed
+}
 export type ParquetReadOptions = BaseParquetReadOptions & (ArrayRowFormat | ObjectRowFormat)
 
 /**

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -12,7 +12,7 @@ describe('parquetQuery', () => {
 
   it('reads data without orderBy', async () => {
     const file = await asyncBufferFromFile('test/files/datapage_v2.snappy.parquet')
-    const rows = await parquetQuery({ file, rowFormat: 'object' })
+    const rows = await parquetQuery({ file })
     expect(rows).toEqual([
       { a: 'abc', b: 1, c: 2, d: true, e: [1, 2, 3] },
       { a: 'abc', b: 2, c: 3, d: true },
@@ -22,21 +22,9 @@ describe('parquetQuery', () => {
     ])
   })
 
-  it('returns rows in "array" format if asked', async () => {
-    const file = await asyncBufferFromFile('test/files/datapage_v2.snappy.parquet')
-    const rows = await parquetQuery({ file, rowFormat: 'array' })
-    expect(rows).toEqual([
-      [ 'abc', 1, 2, true, [1, 2, 3] ],
-      [ 'abc', 2, 3, true, undefined ],
-      [ 'abc', 3, 4, true, undefined ],
-      [ null, 4, 5, false, [1, 2, 3] ],
-      [ 'abc', 5, 2, true, [1, 2] ],
-    ])
-  })
-
   it('reads data with orderBy', async () => {
     const file = await asyncBufferFromFile('test/files/datapage_v2.snappy.parquet')
-    const rows = await parquetQuery({ file, orderBy: 'c', rowFormat: 'object' })
+    const rows = await parquetQuery({ file, orderBy: 'c' })
     expect(rows).toEqual([
       { __index__: 0, a: 'abc', b: 1, c: 2, d: true, e: [1, 2, 3] },
       { __index__: 4, a: 'abc', b: 5, c: 2, d: true, e: [1, 2] },
@@ -48,7 +36,7 @@ describe('parquetQuery', () => {
 
   it('reads data with orderBy and limits', async () => {
     const file = await asyncBufferFromFile('test/files/datapage_v2.snappy.parquet')
-    const rows = await parquetQuery({ file, orderBy: 'c', rowStart: 1, rowEnd: 4, rowFormat: 'object' })
+    const rows = await parquetQuery({ file, orderBy: 'c', rowStart: 1, rowEnd: 4 })
     expect(rows).toEqual([
       { __index__: 4, a: 'abc', b: 5, c: 2, d: true, e: [1, 2] },
       { __index__: 1, a: 'abc', b: 2, c: 3, d: true },
@@ -58,7 +46,7 @@ describe('parquetQuery', () => {
 
   it('reads data with rowStart and rowEnd without orderBy', async () => {
     const file = await asyncBufferFromFile('test/files/datapage_v2.snappy.parquet')
-    const rows = await parquetQuery({ file, rowStart: 1, rowEnd: 4, rowFormat: 'object' })
+    const rows = await parquetQuery({ file, rowStart: 1, rowEnd: 4 })
     expect(rows).toEqual([
       { a: 'abc', b: 2, c: 3, d: true },
       { a: 'abc', b: 3, c: 4, d: true },
@@ -75,15 +63,13 @@ describe('parquetQuery', () => {
     ])
   })
 
-  it('always returns rows in "object" format if filter is provided', async () => {
+  it('always returns rows in "object" format', async () => {
     const file = await asyncBufferFromFile('test/files/datapage_v2.snappy.parquet')
     const expected = [
       { a: 'abc', b: 1, c: 2, d: true, e: [ 1, 2, 3 ] },
       { a: 'abc', b: 5, c: 2, d: true, e: [ 1, 2 ] },
     ]
     const filter = { c: { $eq: 2 } }
-    expect(await parquetQuery({ file, filter, rowFormat: 'array' })).toEqual(expected)
-    expect(await parquetQuery({ file, filter, rowFormat: 'object' })).toEqual(expected)
     expect(await parquetQuery({ file, filter })).toEqual(expected)
   })
 

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -63,16 +63,6 @@ describe('parquetQuery', () => {
     ])
   })
 
-  it('always returns rows in "object" format', async () => {
-    const file = await asyncBufferFromFile('test/files/datapage_v2.snappy.parquet')
-    const expected = [
-      { a: 'abc', b: 1, c: 2, d: true, e: [ 1, 2, 3 ] },
-      { a: 'abc', b: 5, c: 2, d: true, e: [ 1, 2 ] },
-    ]
-    const filter = { c: { $eq: 2 } }
-    expect(await parquetQuery({ file, filter })).toEqual(expected)
-  })
-
   it('reads data with filter and rowStart/rowEnd', async () => {
     const file = await asyncBufferFromFile('test/files/datapage_v2.snappy.parquet')
     const rows = await parquetQuery({ file, filter: { c: { $eq: 2 } }, rowStart: 1, rowEnd: 5 })

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -12,7 +12,7 @@ describe('parquetQuery', () => {
 
   it('reads data without orderBy', async () => {
     const file = await asyncBufferFromFile('test/files/datapage_v2.snappy.parquet')
-    const rows = await parquetQuery({ file })
+    const rows = await parquetQuery({ file, rowFormat: 'object' })
     expect(rows).toEqual([
       { a: 'abc', b: 1, c: 2, d: true, e: [1, 2, 3] },
       { a: 'abc', b: 2, c: 3, d: true },
@@ -36,7 +36,7 @@ describe('parquetQuery', () => {
 
   it('reads data with orderBy', async () => {
     const file = await asyncBufferFromFile('test/files/datapage_v2.snappy.parquet')
-    const rows = await parquetQuery({ file, orderBy: 'c' })
+    const rows = await parquetQuery({ file, orderBy: 'c', rowFormat: 'object' })
     expect(rows).toEqual([
       { __index__: 0, a: 'abc', b: 1, c: 2, d: true, e: [1, 2, 3] },
       { __index__: 4, a: 'abc', b: 5, c: 2, d: true, e: [1, 2] },
@@ -48,7 +48,7 @@ describe('parquetQuery', () => {
 
   it('reads data with orderBy and limits', async () => {
     const file = await asyncBufferFromFile('test/files/datapage_v2.snappy.parquet')
-    const rows = await parquetQuery({ file, orderBy: 'c', rowStart: 1, rowEnd: 4 })
+    const rows = await parquetQuery({ file, orderBy: 'c', rowStart: 1, rowEnd: 4, rowFormat: 'object' })
     expect(rows).toEqual([
       { __index__: 4, a: 'abc', b: 5, c: 2, d: true, e: [1, 2] },
       { __index__: 1, a: 'abc', b: 2, c: 3, d: true },
@@ -58,7 +58,7 @@ describe('parquetQuery', () => {
 
   it('reads data with rowStart and rowEnd without orderBy', async () => {
     const file = await asyncBufferFromFile('test/files/datapage_v2.snappy.parquet')
-    const rows = await parquetQuery({ file, rowStart: 1, rowEnd: 4 })
+    const rows = await parquetQuery({ file, rowStart: 1, rowEnd: 4, rowFormat: 'object' })
     expect(rows).toEqual([
       { a: 'abc', b: 2, c: 3, d: true },
       { a: 'abc', b: 3, c: 4, d: true },


### PR DESCRIPTION
**Breaking change**: only support object format for `parquetReadObjects` and `parquetQuery`

Note that we use the `@overload` directive to provide multiple function signatures. See https://devblogs.microsoft.com/typescript/announcing-typescript-5-0-beta/#@overload-support-in-jsdoc and https://austingil.com/typescript-function-overloads-with-jsdoc/

