### PR TITLE
For discussion: Add `suffixStart` option to `parquetMetadataAsync`

### DIFF
--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -21,6 +21,14 @@ export interface MetadataOptions {
 }
 
 /**
+ * Options for parquetMetadataAsync
+ */
+export interface MetadataAsyncOptions extends MetadataOptions {
+  initialFetchSize?: number // fetch last N bytes from EOF (default 512kb)
+  suffixStart?: number // if provided, fetch from this byte offset to EOF (overrides initialFetchSize)
+}
+
+/**
  * Parquet query options for reading data
  */
 export interface BaseParquetReadOptions {


### PR DESCRIPTION
Adds a `suffixStart` option to `parquetMetadataAsync` that allows the caller to specify a byte offset to start fetching from (instead of fetching the last `initialFetchSize` bytes).

It's analogous to fetching bytes `[idx:]` (`idx` to EOF) instead of `[-n:]` (current behavior: last `n` bytes).

## Motivation: polling append-only Parquet files

I built [a dashboard][awair] that reads from append-only Parquet files in S3:

1. **On load:** fetch last 512KB of file.
    - We primarily want the footer, but that's usually much smaller, so we get (and cache) a few recent row groups as well.
2. **Every minute**: fetch from [last row group's start offset] to EOF
    - The purpose is to re-fetch the last row group (which is expected to have grown by 1 row each minute) plus the new footer.
    - I know the byte offset to fetch from (from my previous footer fetch; I also expect row-group start-idxs to be immutable), but `initialFetchSize` doesn't let me express that directly.

## Example usage

From [runsascoded/awair parquetCache.ts][example]:

```ts
// Initial fetch: use initialFetchSize (last N bytes)
this.metadata = await parquetMetadataAsync(asyncBuffer, {
  initialFetchSize: this.initialFetchSize
})

// Refresh: fetch from last RG start to EOF
const lastRgInfo = this.rowGroupInfos[this.rowGroupInfos.length - 1]
const fetchStart = lastRgInfo.startByte
this.metadata = await parquetMetadataAsync(asyncBuffer, {
  suffixStart: fetchStart  // "fetch from byte fetchStart to EOF"
})
```

## Changes

- Add `suffixStart` option to `MetadataAsyncOptions`
- When provided, use it directly instead of calculating `byteLength - initialFetchSize`
- Backwards compatible: existing behavior unchanged

Happy to discuss whether this is the right API shape, or whether it's too niche of a use-case to bother including here.

I also used [runsascoded/gh-pnpm-dist] to publish [`6d0c51c`] (from [`b81f95d`]), including this change, which I then [use][gh dep] in my dashboard, so I'm not blocked on upstreaming this.

[example]: https://github.com/runsascoded/awair/blob/3bda75da1a544ed08396e89f5bb9b5bd1a8462e1/www/src/services/parquetCache.ts#L179-L181
[awair]: https://awair.runsascoded.com/?d=+br&t=-3d&y=th
[gh dep]: https://github.com/runsascoded/awair/blob/acd740cd98fb1c30254efc23e1a640e6f20a209d/www/package.json#L31
[runsascoded/gh-pnpm-dist]: https://github.com/runsascoded/gh-pnpm-dist
[`b81f95d`]: https://github.com/runsascoded/hyparquet/commit/b81f95d4efef79cf80b7b45c04d4f5ed8bb5d761
[`6d0c51c`]: https://github.com/runsascoded/hyparquet/tree/6d0c51c

[hyparam/hyparquet#142]: https://github.com/hyparam/hyparquet/pull/142

<!-- Synced with https://gist.github.com/178195c03afd8ee3741e690141c9016c/1d27cbb5cbd33c8aa6ccc671e6dda42dd31d1be7 via [ghpr](https://github.com/runsascoded/ghpr) -->