### PR TITLE
SubColumnData type for onPage

### DIFF
--- a/src/column.js
+++ b/src/column.js
@@ -12,11 +12,11 @@ import { deserializeTCompactProtocol } from './thrift.js'
  * @param {DataReader} reader
  * @param {RowGroupSelect} rowGroupSelect row group selection
  * @param {ColumnDecoder} columnDecoder column decoder params
- * @param {(chunk: ColumnData) => void} [onPage] callback for each page
+ * @param {(chunk: SubColumnData) => void} [onPage] callback for each page
  * @returns {DecodedArray[]}
  */
 export function readColumn(reader, { groupStart, selectStart, selectEnd }, columnDecoder, onPage) {
-  const { columnName, schemaPath } = columnDecoder
+  const { pathInSchema, schemaPath } = columnDecoder
   const isFlat = isFlatColumn(schemaPath)
   /** @type {DecodedArray[]} */
   const chunks = []
@@ -28,7 +28,7 @@ export function readColumn(reader, { groupStart, selectStart, selectEnd }, colum
 
   const emitLastChunk = onPage && (() => {
     lastChunk && onPage({
-      columnName,
+      pathInSchema,
       columnData: lastChunk,
       rowStart: groupStart + rowCount - lastChunk.length,
       rowEnd: groupStart + rowCount,
@@ -148,7 +148,7 @@ export function readPage(reader, header, columnDecoder, dictionary, previousChun
 /**
  * Read parquet header from a buffer.
  *
- * @import {ColumnData, ColumnDecoder, DataReader, DecodedArray, PageHeader, RowGroupSelect} from '../src/types.d.ts'
+ * @import {ColumnDecoder, DataReader, DecodedArray, PageHeader, RowGroupSelect, SubColumnData} from '../src/types.d.ts'
  * @param {DataReader} reader
  * @returns {PageHeader}
  */

--- a/src/rowgroup.js
+++ b/src/rowgroup.js
@@ -54,9 +54,8 @@ export function readRowGroup(options, { metadata, columns }, groupPlan) {
       data: buffer.then(arrayBuffer => {
         const schemaPath = getSchemaPath(metadata.schema, meta_data.path_in_schema)
         const reader = { view: new DataView(arrayBuffer), offset: 0 }
-        const subcolumn = meta_data.path_in_schema.join('.')
         const columnDecoder = {
-          columnName: subcolumn,
+          pathInSchema: meta_data.path_in_schema,
           type: meta_data.type,
           element: schemaPath[schemaPath.length - 1].element,
           schemaPath,

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -31,7 +31,7 @@ export interface BaseParquetReadOptions {
   rowStart?: number // first requested row index (inclusive)
   rowEnd?: number // last requested row index (exclusive)
   onChunk?: (chunk: ColumnData) => void // called when a column chunk is parsed. chunks may contain data outside the requested range.
-  onPage?: (chunk: ColumnData) => void // called when a data page is parsed. pages may contain data outside the requested range.
+  onPage?: (chunk: SubColumnData) => void // called when a data page is parsed. pages may contain data outside the requested range.
   compressors?: Compressors // custom decompressors
   utf8?: boolean // decode byte arrays as utf8 strings (default true)
   parsers?: ParquetParsers // custom parsers to decode advanced types
@@ -75,6 +75,15 @@ export type ParquetQueryOperator = {
  */
 export interface ColumnData {
   columnName: string
+  columnData: DecodedArray
+  rowStart: number
+  rowEnd: number // exclusive
+}
+/**
+ * A run of sub-column data (pre-assembly)
+ */
+export interface SubColumnData {
+  pathInSchema: string[]
   columnData: DecodedArray
   rowStart: number
   rowEnd: number // exclusive
@@ -426,7 +435,7 @@ interface GroupPlan {
 }
 
 export interface ColumnDecoder {
-  columnName: string
+  pathInSchema: string[]
   type: ParquetType
   element: SchemaElement
   schemaPath: SchemaTree[]

--- a/test/column.test.js
+++ b/test/column.test.js
@@ -26,7 +26,7 @@ describe('readColumn', () => {
     const schemaPath = getSchemaPath(metadata.schema, column.meta_data?.path_in_schema ?? [])
     const reader = { view: new DataView(columnArrayBuffer), offset: 0 }
     const columnDecoder = {
-      columnName: column.meta_data.path_in_schema.join('.'),
+      pathInSchema: column.meta_data.path_in_schema,
       type: column.meta_data.type,
       element: schemaPath[schemaPath.length - 1].element,
       schemaPath,
@@ -57,7 +57,7 @@ describe('readColumn', () => {
     const schemaPath = getSchemaPath(metadata.schema, column.meta_data?.path_in_schema ?? [])
     const reader = { view: new DataView(columnArrayBuffer), offset: 0 }
     const columnDecoder = {
-      columnName: column.meta_data.path_in_schema.join('.'),
+      pathInSchema: column.meta_data.path_in_schema,
       type: column.meta_data.type,
       element: schemaPath[schemaPath.length - 1].element,
       schemaPath,

--- a/test/read.test.js
+++ b/test/read.test.js
@@ -199,7 +199,7 @@ describe('parquetRead', () => {
 
   it('reads individual pages', async () => {
     const file = countingBuffer(await asyncBufferFromFile('test/files/page_indexed.parquet'))
-    /** @type {import('../src/types.js').ColumnData[]} */
+    /** @type {import('../src/types.js').SubColumnData[]} */
     const pages = []
 
     // check onPage callback
@@ -212,13 +212,13 @@ describe('parquetRead', () => {
 
     const expectedPages = [
       {
-        columnName: 'row',
+        pathInSchema: ['row'],
         columnData: Array.from({ length: 100 }, (_, i) => BigInt(i)),
         rowStart: 0,
         rowEnd: 100,
       },
       {
-        columnName: 'quality',
+        pathInSchema: ['quality'],
         columnData: [
           'bad', 'bad', 'bad', 'bad', 'bad', 'bad', 'good', 'bad', 'bad', 'bad',
           'good', 'bad', 'bad', 'bad', 'bad', 'bad', 'bad', 'bad', 'bad', 'bad',
@@ -235,13 +235,13 @@ describe('parquetRead', () => {
         rowEnd: 100,
       },
       {
-        columnName: 'row',
+        pathInSchema: ['row'],
         columnData: Array.from({ length: 100 }, (_, i) => BigInt(i + 100)),
         rowStart: 100,
         rowEnd: 200,
       },
       {
-        columnName: 'quality',
+        pathInSchema: ['quality'],
         columnData: [
           'good', 'bad', 'bad', 'bad', 'bad', 'bad', 'bad', 'bad', 'bad', 'good',
           'bad', 'bad', 'bad', 'bad', 'bad', 'bad', 'bad', 'bad', 'bad', 'bad',
@@ -261,7 +261,7 @@ describe('parquetRead', () => {
 
     // expect each page to exist in expected
     for (const expected of expectedPages) {
-      const page = pages.find(p => p.columnName === expected.columnName && p.rowStart === expected.rowStart)
+      const page = pages.find(p => p.pathInSchema[0] === expected.pathInSchema[0] && p.rowStart === expected.rowStart)
       expect(page).toEqual(expected)
     }
     expect(file.fetches).toBe(3) // 1 metadata, 2 rowgroups


### PR DESCRIPTION
Change `onPage` to return `pathInSchema: string[]` instead of `columnName: string`.

Which makes clear that `onPage` returns a sub-column (can be nested, with multi-step `pathInSchema`) whereas `onChunk` returns a top-level assembled column with just a top-level `columnName`.

Technically a breaking change, but I doubt many people are using `onPage` callback. If you are using `onPage` with `columnName` this is now equivalent: `const columnName = pathInSchema.join('.')`. This should be strictly better since you can now distinguish subcolumns from top level columns with name like `a.b`.