### PR TITLE
Strict equality option

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![minzipped](https://img.shields.io/bundlephobia/minzip/hyparquet)](https://www.npmjs.com/package/hyparquet)
 [![workflow status](https://github.com/hyparam/hyparquet/actions/workflows/ci.yml/badge.svg)](https://github.com/hyparam/hyparquet/actions)
 [![mit license](https://img.shields.io/badge/License-MIT-orange.svg)](https://opensource.org/licenses/MIT)
-![coverage](https://img.shields.io/badge/Coverage-96-darkred)
+![coverage](https://img.shields.io/badge/Coverage-92-darkred)
 [![dependencies](https://img.shields.io/badge/Dependencies-0-blueviolet)](https://www.npmjs.com/package/hyparquet?activeTab=dependencies)
 
 Dependency free since 2023!

--- a/src/filter.js
+++ b/src/filter.js
@@ -5,18 +5,18 @@ import { equals } from './utils.js'
  *
  * @param {Record<string, any>} record
  * @param {ParquetQueryFilter} filter
+ * @param {boolean} [strict]
  * @returns {boolean}
- * @example matchQuery({ id: 1 }, { id: {$gte: 1} }) // true
  */
-export function matchFilter(record, filter = {}) {
+export function matchFilter(record, filter, strict = true) {
   if ('$and' in filter && Array.isArray(filter.$and)) {
-    return filter.$and.every(subQuery => matchFilter(record, subQuery))
+    return filter.$and.every(subQuery => matchFilter(record, subQuery, strict))
   }
   if ('$or' in filter && Array.isArray(filter.$or)) {
-    return filter.$or.some(subQuery => matchFilter(record, subQuery))
+    return filter.$or.some(subQuery => matchFilter(record, subQuery, strict))
   }
   if ('$nor' in filter && Array.isArray(filter.$nor)) {
-    return !filter.$nor.some(subQuery => matchFilter(record, subQuery))
+    return !filter.$nor.some(subQuery => matchFilter(record, subQuery, strict))
   }
 
   return Object.entries(filter).every(([field, condition]) => {
@@ -24,7 +24,7 @@ export function matchFilter(record, filter = {}) {
 
     // implicit $eq for non-object conditions
     if (typeof condition !== 'object' || condition === null || Array.isArray(condition)) {
-      return equals(value, condition)
+      return equals(value, condition, strict)
     }
 
     return Object.entries(condition || {}).every(([operator, target]) => {
@@ -32,11 +32,11 @@ export function matchFilter(record, filter = {}) {
       if (operator === '$gte') return value >= target
       if (operator === '$lt') return value < target
       if (operator === '$lte') return value <= target
-      if (operator === '$eq') return equals(value, target)
-      if (operator === '$ne') return !equals(value, target)
+      if (operator === '$eq') return equals(value, target, strict)
+      if (operator === '$ne') return !equals(value, target, strict)
       if (operator === '$in') return Array.isArray(target) && target.includes(value)
       if (operator === '$nin') return Array.isArray(target) && !target.includes(value)
-      if (operator === '$not') return !matchFilter({ [field]: value }, { [field]: target })
+      if (operator === '$not') return !matchFilter({ [field]: value }, { [field]: target }, strict)
       return true
     })
   })
@@ -46,22 +46,24 @@ export function matchFilter(record, filter = {}) {
  * Check if a row group can be skipped based on filter and column statistics.
  *
  * @import {ParquetQueryFilter, RowGroup} from '../src/types.js'
- * @param {ParquetQueryFilter | undefined} filter
- * @param {RowGroup} group
- * @param {string[]} physicalColumns
+ * @param {object} options
+ * @param {RowGroup} options.rowGroup
+ * @param {string[]} options.physicalColumns
+ * @param {ParquetQueryFilter | undefined} options.filter
+ * @param {boolean} [options.strict]
  * @returns {boolean} true if the row group can be skipped
  */
-export function canSkipRowGroup(filter, group, physicalColumns) {
+export function canSkipRowGroup({ rowGroup, physicalColumns, filter, strict = true }) {
   if (!filter) return false
 
   // Handle logical operators
   if ('$and' in filter && Array.isArray(filter.$and)) {
     // For AND, we can skip if ANY condition allows skipping
-    return filter.$and.some(subFilter => canSkipRowGroup(subFilter, group, physicalColumns))
+    return filter.$and.some(subFilter => canSkipRowGroup({ rowGroup, physicalColumns, filter: subFilter, strict }))
   }
   if ('$or' in filter && Array.isArray(filter.$or)) {
     // For OR, we can skip only if ALL conditions allow skipping
-    return filter.$or.every(subFilter => canSkipRowGroup(subFilter, group, physicalColumns))
+    return filter.$or.every(subFilter => canSkipRowGroup({ rowGroup, physicalColumns, filter: subFilter, strict }))
   }
   if ('$nor' in filter && Array.isArray(filter.$nor)) {
     // For NOR, we can skip if none of the conditions allow skipping
@@ -75,8 +77,7 @@ export function canSkipRowGroup(filter, group, physicalColumns) {
     const columnIndex = physicalColumns.indexOf(field)
     if (columnIndex === -1) continue
 
-    const columnChunk = group.columns[columnIndex]
-    const stats = columnChunk.meta_data?.statistics
+    const stats = rowGroup.columns[columnIndex].meta_data?.statistics
     if (!stats) continue // No statistics available, can't skip
 
     const { min, max, min_value, max_value } = stats
@@ -92,9 +93,9 @@ export function canSkipRowGroup(filter, group, physicalColumns) {
       if (operator === '$lt' && minVal >= target) return true
       if (operator === '$lte' && minVal > target) return true
       if (operator === '$eq' && (target < minVal || target > maxVal)) return true
-      if (operator === '$ne' && equals(minVal, maxVal) && equals(minVal, target)) return true
+      if (operator === '$ne' && equals(minVal, maxVal, strict) && equals(minVal, target, strict)) return true
       if (operator === '$in' && Array.isArray(target) && target.every(v => v < minVal || v > maxVal)) return true
-      if (operator === '$nin' && Array.isArray(target) && equals(minVal, maxVal) && target.includes(minVal)) return true
+      if (operator === '$nin' && Array.isArray(target) && equals(minVal, maxVal, strict) && target.includes(minVal)) return true
     }
   }
 

--- a/src/plan.js
+++ b/src/plan.js
@@ -16,7 +16,7 @@ const columnChunkAggregation = 1 << 25 // 32mb
  * @param {ParquetReadOptions} options
  * @returns {QueryPlan}
  */
-export function parquetPlan({ metadata, rowStart = 0, rowEnd = Infinity, columns, filter }) {
+export function parquetPlan({ metadata, rowStart = 0, rowEnd = Infinity, columns, filter, filterStrict = true }) {
   if (!metadata) throw new Error('parquetPlan requires metadata')
   /** @type {GroupPlan[]} */
   const groups = []
@@ -30,7 +30,7 @@ export function parquetPlan({ metadata, rowStart = 0, rowEnd = Infinity, columns
     const groupRows = Number(rowGroup.num_rows)
     const groupEnd = groupStart + groupRows
     // if row group overlaps with row range, add it to the plan
-    if (groupRows > 0 && groupEnd > rowStart && groupStart < rowEnd && !canSkipRowGroup(filter, rowGroup, physicalColumns)) {
+    if (groupRows > 0 && groupEnd > rowStart && groupStart < rowEnd && !canSkipRowGroup({ rowGroup, physicalColumns, filter, strict: filterStrict })) {
       /** @type {ByteRange[]} */
       const ranges = []
       // loop through each column chunk

--- a/src/query.js
+++ b/src/query.js
@@ -20,7 +20,7 @@ export async function parquetQuery(options) {
   }
   options.metadata ??= await parquetMetadataAsync(options.file, options)
 
-  const { metadata, rowStart = 0, columns, orderBy, filter } = options
+  const { metadata, rowStart = 0, columns, orderBy, filter, filterStrict = true } = options
   if (rowStart < 0) throw new Error('parquet rowStart must be positive')
   const rowEnd = options.rowEnd ?? Number(metadata.num_rows)
 
@@ -54,7 +54,7 @@ export async function parquetQuery(options) {
       })
       // filter and project rows
       for (const row of groupData) {
-        if (matchFilter(row, filter)) {
+        if (matchFilter(row, filter, filterStrict)) {
           if (requiresProjection && relevantColumns) {
             for (const column of relevantColumns) {
               if (columns && !columns.includes(column)) {
@@ -82,7 +82,7 @@ export async function parquetQuery(options) {
     /** @type {Record<string, any>[]} */
     const filteredRows = new Array()
     for (const row of results) {
-      if (matchFilter(row, filter)) {
+      if (matchFilter(row, filter, filterStrict)) {
         if (requiresProjection && relevantColumns) {
           for (const column of relevantColumns) {
             if (columns && !columns.includes(column)) {

--- a/src/schema.js
+++ b/src/schema.js
@@ -60,7 +60,7 @@ export function getPhysicalColumns(schemaTree) {
         traverse(child)
       }
     } else {
-      columns.push(node.element.name)
+      columns.push(node.path.join('.'))
     }
   }
   traverse(schemaTree)

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -28,6 +28,7 @@ export interface BaseParquetReadOptions {
   metadata?: FileMetaData // parquet metadata, will be parsed if not provided
   columns?: string[] // columns to read, all columns if undefined
   filter?: ParquetQueryFilter // best-effort pushdown filter, NOT GUARANTEED to be applied
+  filterStrict?: boolean // if true filtering uses strict equality (default true)
   rowStart?: number // first requested row index (inclusive)
   rowEnd?: number // last requested row index (exclusive)
   onChunk?: (chunk: ColumnData) => void // called when a column chunk is parsed. chunks may contain data outside the requested range.

--- a/src/utils.js
+++ b/src/utils.js
@@ -27,8 +27,8 @@ export function toJson(obj) {
 /**
  * Concatenate two arrays fast.
  *
- * @param {any[]} aaa first array
- * @param {DecodedArray} bbb second array
+ * @param {any[]} aaa
+ * @param {DecodedArray} bbb
  */
 export function concat(aaa, bbb) {
   const chunk = 10000
@@ -38,19 +38,32 @@ export function concat(aaa, bbb) {
 }
 
 /**
- * Deep equality comparison
+ * Deep equality.
  *
- * @param {any} a First object to compare
- * @param {any} b Second object to compare
- * @returns {boolean} true if objects are equal
+ * @param {any} a
+ * @param {any} b
+ * @param {boolean} [strict]
+ * @returns {boolean}
  */
-export function equals(a, b) {
-  if (a === b) return true
-  if (a instanceof Uint8Array && b instanceof Uint8Array) return equals(Array.from(a), Array.from(b))
+export function equals(a, b, strict = true) {
+  // eslint-disable-next-line eqeqeq
+  if (strict ? a === b : a == b) return true
+  if (a instanceof Uint8Array && b instanceof Uint8Array) return equals(Array.from(a), Array.from(b), strict)
   if (!a || !b || typeof a !== typeof b) return false
-  return Array.isArray(a) && Array.isArray(b)
-    ? a.length === b.length && a.every((v, i) => equals(v, b[i]))
-    : typeof a === 'object' && Object.keys(a).length === Object.keys(b).length && Object.keys(a).every(k => equals(a[k], b[k]))
+  if (Array.isArray(a) && Array.isArray(b)) {
+    if (a.length !== b.length) return false
+    for (let i = 0; i < a.length; i++) {
+      if (!equals(a[i], b[i], strict)) return false
+    }
+    return true
+  }
+  if (typeof a !== 'object') return false
+  const aKeys = Object.keys(a)
+  if (aKeys.length !== Object.keys(b).length) return false
+  for (const k of aKeys) {
+    if (!equals(a[k], b[k], strict)) return false
+  }
+  return true
 }
 
 /**

--- a/test/filter.test.js
+++ b/test/filter.test.js
@@ -1,0 +1,147 @@
+import { describe, expect, it } from 'vitest'
+import { canSkipRowGroup, matchFilter } from '../src/filter.js'
+
+/**
+ * @import { RowGroup } from '../src/types.js'
+ */
+
+describe('matchFilter', () => {
+  it('handles logical operators $and, $or, $nor', () => {
+    const record = { a: 5, b: 10 }
+    expect(matchFilter(record, { $and: [{ a: { $eq: 5 } }, { b: { $eq: 10 } }] })).toBe(true)
+    expect(matchFilter(record, { $and: [{ a: { $eq: 5 } }, { b: { $eq: 99 } }] })).toBe(false)
+    expect(matchFilter(record, { $or: [{ a: { $eq: 1 } }, { b: { $eq: 10 } }] })).toBe(true)
+    expect(matchFilter(record, { $or: [{ a: { $eq: 1 } }, { b: { $eq: 99 } }] })).toBe(false)
+    expect(matchFilter(record, { $nor: [{ a: { $eq: 1 } }, { b: { $eq: 99 } }] })).toBe(true)
+    expect(matchFilter(record, { $nor: [{ a: { $eq: 5 } }, { b: { $eq: 99 } }] })).toBe(false)
+  })
+
+  it('handles comparison operators', () => {
+    const record = { x: 10 }
+    expect(matchFilter(record, { x: { $gt: 9 } })).toBe(true)
+    expect(matchFilter(record, { x: { $gt: 10 } })).toBe(false)
+    expect(matchFilter(record, { x: { $gte: 10 } })).toBe(true)
+    expect(matchFilter(record, { x: { $lt: 11 } })).toBe(true)
+    expect(matchFilter(record, { x: { $lt: 10 } })).toBe(false)
+    expect(matchFilter(record, { x: { $lte: 10 } })).toBe(true)
+    expect(matchFilter(record, { x: { $eq: 10 } })).toBe(true)
+    expect(matchFilter(record, { x: { $ne: 10 } })).toBe(false)
+    expect(matchFilter(record, { x: { $ne: 5 } })).toBe(true)
+  })
+
+  it('handles $in, $nin, and $not operators', () => {
+    const record = { x: 5 }
+    expect(matchFilter(record, { x: { $in: [1, 5, 10] } })).toBe(true)
+    expect(matchFilter(record, { x: { $in: [1, 2, 3] } })).toBe(false)
+    expect(matchFilter(record, { x: { $nin: [1, 2, 3] } })).toBe(true)
+    expect(matchFilter(record, { x: { $nin: [5, 6, 7] } })).toBe(false)
+    expect(matchFilter(record, { x: { $not: { $gt: 10 } } })).toBe(true)
+    expect(matchFilter(record, { x: { $not: { $lt: 10 } } })).toBe(false)
+  })
+
+  it('uses strict equality (===) when strict is true', () => {
+    expect(matchFilter({ x: 5 }, { x: { $eq: '5' } }, true)).toBe(false)
+    expect(matchFilter({ x: 5 }, { x: { $ne: '5' } }, true)).toBe(true)
+  })
+
+  it('uses loose equality (==) when strict is false', () => {
+    expect(matchFilter({ x: 5 }, { x: { $eq: '5' } }, false)).toBe(true)
+    expect(matchFilter({ x: 5 }, { x: { $ne: '5' } }, false)).toBe(false)
+  })
+})
+
+describe('canSkipRowGroup', () => {
+  /**
+   * @param {number} min
+   * @param {number} max
+   * @returns {RowGroup}
+   */
+  function makeRowGroup(min, max) {
+    return {
+      columns: [{
+        meta_data: {
+          type: 'INT32',
+          path_in_schema: ['a'],
+          codec: 'UNCOMPRESSED',
+          num_values: 1000n,
+          total_compressed_size: 2048n,
+          total_uncompressed_size: 4096n,
+          encodings: ['PLAIN'],
+          data_page_offset: 4n,
+          statistics: { min_value: min, max_value: max },
+        },
+        file_offset: 4n,
+      }],
+      total_byte_size: 4096n,
+      num_rows: 1000n,
+    }
+  }
+
+  it('returns false when no filter or column not found', () => {
+    expect(canSkipRowGroup({ filter: { unknown: { $gt: 5 } }, rowGroup: makeRowGroup(1, 10), physicalColumns: ['x'] })).toBe(false)
+  })
+
+  it('returns false when no statistics available', () => {
+    /** @type {any} */
+    const rowGroup = { columns: [{ meta_data: {} }] }
+    expect(canSkipRowGroup({ filter: { x: { $gt: 5 } }, rowGroup, physicalColumns: ['x'] })).toBe(false)
+  })
+
+  it('handles logical operators', () => {
+    const rowGroup = makeRowGroup(10, 20)
+    const cols = ['x']
+    // $and: skip if ANY allows
+    expect(canSkipRowGroup({ filter: { $and: [{ x: { $gt: 100 } }] }, rowGroup, physicalColumns: cols })).toBe(true)
+    expect(canSkipRowGroup({ filter: { $and: [{ x: { $gt: 5 } }] }, rowGroup, physicalColumns: cols })).toBe(false)
+    // $or: skip only if ALL allow
+    expect(canSkipRowGroup({ filter: { $or: [{ x: { $gt: 100 } }, { x: { $lt: 5 } }] }, rowGroup, physicalColumns: cols })).toBe(true)
+    expect(canSkipRowGroup({ filter: { $or: [{ x: { $gt: 5 } }, { x: { $lt: 5 } }] }, rowGroup, physicalColumns: cols })).toBe(false)
+    // $nor: always conservative
+    expect(canSkipRowGroup({ filter: { $nor: [{ x: { $gt: 100 } }] }, rowGroup, physicalColumns: cols })).toBe(false)
+  })
+
+  it('skips based on comparison operators', () => {
+    const rowGroup = makeRowGroup(10, 20)
+    const cols = ['x']
+    // $gt: skip if max <= target
+    expect(canSkipRowGroup({ filter: { x: { $gt: 20 } }, rowGroup, physicalColumns: cols })).toBe(true)
+    expect(canSkipRowGroup({ filter: { x: { $gt: 15 } }, rowGroup, physicalColumns: cols })).toBe(false)
+    // $gte: skip if max < target
+    expect(canSkipRowGroup({ filter: { x: { $gte: 21 } }, rowGroup, physicalColumns: cols })).toBe(true)
+    // $lt: skip if min >= target
+    expect(canSkipRowGroup({ filter: { x: { $lt: 10 } }, rowGroup, physicalColumns: cols })).toBe(true)
+    expect(canSkipRowGroup({ filter: { x: { $lt: 15 } }, rowGroup, physicalColumns: cols })).toBe(false)
+    // $lte: skip if min > target
+    expect(canSkipRowGroup({ filter: { x: { $lte: 9 } }, rowGroup, physicalColumns: cols })).toBe(true)
+    // $eq: skip if target outside range
+    expect(canSkipRowGroup({ filter: { x: { $eq: 5 } }, rowGroup, physicalColumns: cols })).toBe(true)
+    expect(canSkipRowGroup({ filter: { x: { $eq: 25 } }, rowGroup, physicalColumns: cols })).toBe(true)
+    expect(canSkipRowGroup({ filter: { x: { $eq: 15 } }, rowGroup, physicalColumns: cols })).toBe(false)
+  })
+
+  it('skips based on $ne, $in, $nin with uniform values', () => {
+    const uniformRowGroup = makeRowGroup(5, 5)
+    const cols = ['x']
+    // $ne: skip only if min === max === target
+    expect(canSkipRowGroup({ filter: { x: { $ne: 5 } }, rowGroup: uniformRowGroup, physicalColumns: cols })).toBe(true)
+    expect(canSkipRowGroup({ filter: { x: { $ne: 6 } }, rowGroup: uniformRowGroup, physicalColumns: cols })).toBe(false)
+    // $in: skip if all values outside range
+    expect(canSkipRowGroup({ filter: { x: { $in: [1, 2, 3] } }, rowGroup: uniformRowGroup, physicalColumns: cols })).toBe(true)
+    expect(canSkipRowGroup({ filter: { x: { $in: [4, 5, 6] } }, rowGroup: uniformRowGroup, physicalColumns: cols })).toBe(false)
+    // $nin: skip only if uniform and value in array
+    expect(canSkipRowGroup({ filter: { x: { $nin: [5, 6, 7] } }, rowGroup: uniformRowGroup, physicalColumns: cols })).toBe(true)
+    expect(canSkipRowGroup({ filter: { x: { $nin: [1, 2, 3] } }, rowGroup: uniformRowGroup, physicalColumns: cols })).toBe(false)
+  })
+
+  it('handles min/max fallback to legacy fields', () => {
+    /** @type {any} */
+    const rowGroup = { columns: [{ meta_data: { statistics: { min: 10, max: 20 } } }] }
+    expect(canSkipRowGroup({ filter: { x: { $gt: 25 } }, rowGroup, physicalColumns: ['x'] })).toBe(true)
+  })
+
+  it('continues when min or max undefined', () => {
+    /** @type {any} */
+    const rowGroup = { columns: [{ meta_data: { statistics: { min_value: 10 } } }] }
+    expect(canSkipRowGroup({ filter: { x: { $gt: 5 } }, rowGroup, physicalColumns: ['x'] })).toBe(false)
+  })
+})


### PR DESCRIPTION
Adds an option for `filterStrict`.

If `filterStrict` is `true`, then filter queries will use strict equality (`'3' !== 3`). If `filterStrict` is `false`, use non-strict equality (`'3' == 3`).

Defaults to `true` (matches existing behavior, set false for loose equality)
