### PR TITLE
useOffsetIndex

### DIFF
--- a/src/read.js
+++ b/src/read.js
@@ -69,9 +69,9 @@ export async function parquetRead(options) {
   if (onChunk) {
     for (const asyncGroup of assembled) {
       for (const asyncColumn of asyncGroup.asyncColumns) {
-        asyncColumn.data.then(columnDatas => {
-          let rowStart = asyncGroup.groupStart
-          for (const columnData of columnDatas) {
+        asyncColumn.data.then(({ data, pageSkip }) => {
+          let rowStart = asyncGroup.groupStart + pageSkip
+          for (const columnData of data) {
             onChunk({
               columnName: asyncColumn.pathInSchema[0],
               columnData,
@@ -161,7 +161,7 @@ export async function parquetReadColumn(options) {
   /** @type {DecodedArray[]} */
   const columnData = []
   for (const rg of assembled) {
-    columnData.push(flatten(await rg.asyncColumns[0].data))
+    columnData.push(flatten((await rg.asyncColumns[0].data).data))
   }
   return flatten(columnData)
 }


### PR DESCRIPTION
Add option `useOffsetIndex` to control use of offset index for page filtering (default false)

This can substantially reduce fetch size and time by using parquet OffsetIndex to just straight to a specific page of a large column chunk.

```sql
SELECT * FROM wiki OFFSET 784 LIMIT 1
```

| useOffsetIndex | bytes |
| --- | --- |
| `false` | 6,111,314 |
| `true` | 617,381 |

Note that using the offset index will generally require an additional round-trip fetch done serially. This can be a win in some cases and a loss in others, particularly if the column is small, or latency is high.
