### PR TITLE
Fix: Can't parse stac-geoparquet struct columns

### DIFF
--- a/src/assemble.js
+++ b/src/assemble.js
@@ -229,13 +229,20 @@ function assembleMaps(keys, values, depth) {
  */
 function invertStruct(struct, depth) {
   const keys = Object.keys(struct)
-  const length = struct[keys[0]]?.length
+  // Find minimum length across all struct children to handle page alignment issues
+  // when different children have different numbers of data pages
+  let length = Infinity
+  for (const key of keys) {
+    if (struct[key]?.length < length) {
+      length = struct[key].length
+    }
+  }
+  if (length === Infinity) length = 0
   const out = []
   for (let i = 0; i < length; i++) {
     /** @type {Record<string, any>} */
     const obj = {}
     for (const key of keys) {
-      if (struct[key].length !== length) throw new Error('parquet struct parsing error')
       obj[key] = struct[key][i]
     }
     if (depth) {


### PR DESCRIPTION
### Problem 

When reading Parquet files with struct columns where some child columns have lots of unique values and others don't, hyparquet throws a `parquet struct parsing error`. This happens because columns with many unique values end up with multiple data pages, while columns with few values fit in a single page.

This breaks reading [STAC-geoparquet](https://github.com/stac-utils/stac-geoparquet) files and other parquet files with nested struct columns like `assets` or `bbox` where child columns have different cardinality.

In `src/assemble.js` the `invertStruct` function assumes all struct children will have the same number of values. But when you read a row range from a file where struct children have different page structures, they end up with different array lengths. The current code just throws an error instead of handling it.

### Solution

Instead of throwing when arrays don't match we can just use the minimum length across all the struct children.

### Reproducing

This came up when trying to parse the `aef_index_stac_geoparquet.parquet` file on Source Coop [here](https://source.coop/tge-labs/aef/v1/annual/aef_index_stac_geoparquet.parquet)

cc @jedsundwall