### PR TITLE
Dot notation for filters

### DIFF
--- a/test/filter.test.js
+++ b/test/filter.test.js
@@ -48,6 +48,27 @@ describe('matchFilter', () => {
     expect(matchFilter({ x: 5 }, { x: { $eq: '5' } }, false)).toBe(true)
     expect(matchFilter({ x: 5 }, { x: { $ne: '5' } }, false)).toBe(false)
   })
+
+  it('handles dot-notation for nested struct fields', () => {
+    const record = { bbox: { xmin: -73.1, ymin: 40.9, xmax: -73.0, ymax: 41.0 } }
+    expect(matchFilter(record, { 'bbox.xmin': { $gte: -74, $lte: -73 } })).toBe(true)
+    expect(matchFilter(record, { 'bbox.xmin': { $gte: -72, $lte: -71 } })).toBe(false)
+    expect(matchFilter(record, { 'bbox.xmin': { $eq: -73.1 } })).toBe(true)
+    expect(matchFilter(record, { 'bbox.xmin': { $eq: -73.2 } })).toBe(false)
+  })
+
+  it('handles deeply nested dot-notation', () => {
+    const record = { a: { b: { c: 42 } } }
+    expect(matchFilter(record, { 'a.b.c': { $eq: 42 } })).toBe(true)
+    expect(matchFilter(record, { 'a.b.c': { $gt: 40 } })).toBe(true)
+    expect(matchFilter(record, { 'a.b.c': { $lt: 40 } })).toBe(false)
+  })
+
+  it('returns false when nested path does not exist', () => {
+    const record = { a: { b: 1 } }
+    expect(matchFilter(record, { 'a.c': { $eq: 1 } })).toBe(false)
+    expect(matchFilter(record, { 'x.y.z': { $eq: 1 } })).toBe(false)
+  })
 })
 
 describe('canSkipRowGroup', () => {

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -233,6 +233,27 @@ describe('parquetQuery', () => {
     ])
   })
 
+  it('filters on nested struct fields with dot-notation', async () => {
+    const file = await asyncBufferFromFile('test/files/hyparquet_struct.parquet')
+    const rows = await parquetQuery({ file, filter: { 'person.name': { $eq: 'Ada' } } })
+    expect(rows).toEqual([{ person: { name: 'Ada', address: { city: 'London' } } }])
+  })
+
+  it('filters on deeply nested struct fields', async () => {
+    const file = await asyncBufferFromFile('test/files/hyparquet_struct.parquet')
+    const rows = await parquetQuery({ file, filter: { 'person.address.city': { $eq: 'London' } } })
+    expect(rows).toEqual([{ person: { name: 'Ada', address: { city: 'London' } } }])
+  })
+
+  it('filters on nested struct fields with operators', async () => {
+    const file = await asyncBufferFromFile('test/files/hyparquet_struct.parquet')
+    const rows = await parquetQuery({ file, filter: { 'person.name': { $gte: 'B' } } })
+    expect(rows).toEqual([
+      { person: { name: 'Ben' } },
+      { person: { name: 'Cara', address: { city: null } } },
+    ])
+  })
+
   it('throws on non-existent column in filter', async () => {
     const file = await asyncBufferFromFile('test/files/datapage_v2.snappy.parquet')
     await expect(parquetQuery({ file, filter: { nonExistent: { $eq: 1 } } }))


### PR DESCRIPTION
Support dot-notation for filtering on nested struct fields (e.g. `bbox.xmin`).                                                  

Fixes #153
