### PR TITLE
Fix unhandled rejections

### DIFF
--- a/src/read.js
+++ b/src/read.js
@@ -56,9 +56,7 @@ export async function parquetRead(options) {
 
   // skip assembly if no onComplete or onChunk, but wait for reading to finish
   if (!onComplete && !onChunk) {
-    for (const { asyncColumns } of asyncGroups) {
-      for (const { data } of asyncColumns) await data
-    }
+    await awaitAllColumns(asyncGroups)
     return
   }
 
@@ -66,7 +64,7 @@ export async function parquetRead(options) {
   const schemaTree = parquetSchema(options.metadata)
   const assembled = asyncGroups.map(arg => assembleAsync(arg, schemaTree, options.parsers))
 
-  // onChunk emit all chunks (don't await)
+  // onChunk emit all chunks (don't await). Rejection is surfaced by awaitAllColumns below.
   if (onChunk) {
     for (const asyncGroup of assembled) {
       for (const asyncColumn of asyncGroup.asyncColumns) {
@@ -81,13 +79,15 @@ export async function parquetRead(options) {
             })
             rowStart += columnData.length
           }
-        })
+        }, () => {})
       }
     }
   }
 
   // onComplete transpose column chunks to rows
   if (onComplete) {
+    // wait for all reads to settle so a sibling rejection cannot leak
+    await awaitAllColumns(assembled)
     // loosen the types to avoid duplicate code
     /** @type {any[]} */
     const rows = []
@@ -120,10 +120,22 @@ export async function parquetRead(options) {
     onComplete(rows)
   } else {
     // wait for all async groups to finish (complete takes care of this)
-    for (const { asyncColumns } of assembled) {
-      for (const { data } of asyncColumns) await data
-    }
+    await awaitAllColumns(assembled)
   }
+}
+
+/**
+ * Await every column promise across the given row groups via Promise.allSettled
+ * so no rejection escapes as an unhandledRejection. Throws the first rejection.
+ *
+ * @param {AsyncRowGroup[]} asyncGroups
+ * @returns {Promise<void>}
+ */
+async function awaitAllColumns(asyncGroups) {
+  const all = asyncGroups.flatMap(g => g.asyncColumns.map(c => c.data))
+  const results = await Promise.allSettled(all)
+  const failed = results.find(r => r.status === 'rejected')
+  if (failed) throw failed.reason
 }
 
 /**
@@ -158,6 +170,9 @@ export async function parquetReadColumn(options) {
   // assemble struct columns
   const schemaTree = parquetSchema(options.metadata)
   const assembled = asyncGroups.map(arg => assembleAsync(arg, schemaTree, options.parsers))
+
+  // wait for all reads to settle so a sibling rejection cannot leak
+  await awaitAllColumns(assembled)
 
   /** @type {DecodedArray} */
   const columnData = []

--- a/src/rowgroup.js
+++ b/src/rowgroup.js
@@ -191,14 +191,15 @@ export function assembleAsync(asyncRowGroup, schemaTree, parsers) {
       assembled.push({
         pathInSchema: child.path,
         data: (async () => {
-          // collect subcolumn data
+          // collect subcolumn data — Promise.all observes every rejection so
+          // a sibling failure cannot leak as an unhandledRejection
+          const resolved = await Promise.all(childColumns.map(c => c.data))
           /** @type {Map<string, DecodedArray>} */
           const subcolumnData = new Map()
           let minLength = Infinity
-          for (const column of childColumns) {
-            const { data } = await column.data
-            const flat = flatten(data)
-            subcolumnData.set(column.pathInSchema.join('.'), flat)
+          for (let i = 0; i < childColumns.length; i++) {
+            const flat = flatten(resolved[i].data)
+            subcolumnData.set(childColumns[i].pathInSchema.join('.'), flat)
             minLength = Math.min(minLength, flat.length)
           }
           // trim sub-columns to same length (offset index may read different pages per column)

--- a/test/read.test.js
+++ b/test/read.test.js
@@ -5,6 +5,55 @@ import { countingBuffer } from './helpers.js'
 
 vi.mock('../src/convert.js', { spy: true })
 
+/**
+ * @param {() => Promise<void>} callback
+ */
+async function expectNoUnhandledRejections(callback) {
+  /** @type {unknown[]} */
+  const unhandled = []
+  /** @param {unknown} reason */
+  function onUnhandled(reason) {
+    unhandled.push(reason)
+  }
+  process.on('unhandledRejection', onUnhandled)
+  try {
+    await callback()
+    await new Promise(resolve => setTimeout(resolve, 50))
+    expect(unhandled).toEqual([])
+  } finally {
+    process.off('unhandledRejection', onUnhandled)
+  }
+}
+
+/**
+ * @returns {Promise<{ metadata: import('../src/types.js').FileMetaData, file: import('../src/types.js').AsyncBuffer }>}
+ */
+async function rowGroupFailingFile() {
+  const file = await asyncBufferFromFile('test/files/rowgroups.parquet')
+  const metadata = await parquetMetadataAsync(file)
+  const failedColumn = metadata.row_groups[1].columns[0].meta_data
+  if (!failedColumn) throw new Error('expected column metadata')
+  const failedStart = Number(failedColumn.dictionary_page_offset || failedColumn.data_page_offset)
+  const failedEnd = failedStart + Number(failedColumn.total_compressed_size)
+  return {
+    metadata,
+    file: {
+      byteLength: file.byteLength,
+      /**
+       * @param {number} start
+       * @param {number} [end]
+       * @returns {Promise<ArrayBuffer> | ArrayBuffer}
+       */
+      slice(start, end) {
+        if (start === failedStart && end === failedEnd) {
+          return Promise.reject(new Error('simulated read failure'))
+        }
+        return file.slice(start, end)
+      },
+    },
+  }
+}
+
 describe('parquetRead', () => {
   it('throws error for undefined file', async () => {
     // @ts-expect-error testing invalid input
@@ -415,5 +464,23 @@ describe('parquetRead', () => {
     const file = await asyncBufferFromFile('test/files/rle_boolean_encoding.parquet')
     await expect(parquetReadObjects({ file }))
       .rejects.toThrow('parquet unsupported compression codec: GZIP')
+  })
+
+  it('does not leak unhandled rejections when a row group read fails', async () => {
+    const { file, metadata } = await rowGroupFailingFile()
+
+    await expectNoUnhandledRejections(async () => {
+      await expect(parquetReadObjects({ file, metadata }))
+        .rejects.toThrow('simulated read failure')
+    })
+  })
+
+  it('does not leak unhandled rejections from onChunk when a read fails', async () => {
+    const { file, metadata } = await rowGroupFailingFile()
+
+    await expectNoUnhandledRejections(async () => {
+      await expect(parquetRead({ file, metadata, onChunk: vi.fn() }))
+        .rejects.toThrow('simulated read failure')
+    })
   })
 })


### PR DESCRIPTION
 Fixes unhandled promise rejections when Parquet column/row-group reads fail. Fixes #162 (alternate approach from #163)
 
- Awaits all column read promises with Promise.allSettled and rethrows the first error.
- Ensures onChunk callbacks don’t leak rejected promises.
- Updates nested column assembly to observe sibling failures safely.
