### PR TITLE
support GZIP codec natively via DecompressionStream

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,8 +197,10 @@ If Hyparquet detects a [GeoParquet](https://geoparquet.org/) file, any geospatia
 
 ## Compression
 
-By default, hyparquet supports uncompressed and snappy-compressed parquet files.
-To support the full range of parquet compression codecs (gzip, brotli, zstd, etc), use the [hyparquet-compressors](https://github.com/hyparam/hyparquet-compressors) package.
+By default, hyparquet supports uncompressed, snappy-compressed, and gzip-compressed parquet files.
+Gzip uses the native [DecompressionStream](https://developer.mozilla.org/en-US/docs/Web/API/DecompressionStream) API.
+In browsers this is limited to single-member gzip streams (the overwhelmingly common case); rare multi-member pages require a custom gzip decompressor.
+To support the full range of parquet compression codecs (brotli, zstd, etc), use the [hyparquet-compressors](https://github.com/hyparam/hyparquet-compressors) package.
 
 ```javascript
 import { parquetReadObjects } from 'hyparquet'
@@ -211,7 +213,7 @@ const data = await parquetReadObjects({ file, compressors })
 |---------------|-----------|----------------------------|
 | Uncompressed  | ✅        | ✅                         |
 | Snappy        | ✅        | ✅                         |
-| GZip          | ❌        | ✅                         |
+| GZip          | ✅        | ✅                         |
 | LZO           | ❌        | ✅                         |
 | Brotli        | ❌        | ✅                         |
 | LZ4           | ❌        | ✅                         |

--- a/src/column.js
+++ b/src/column.js
@@ -17,9 +17,9 @@ import { deserializeTCompactProtocol } from './thrift.js'
  * @param {RowGroupSelect} rowGroupSelect row group selection
  * @param {ColumnDecoder} columnDecoder column decoder params
  * @param {(chunk: SubColumnData) => void} [onPage] callback for each page
- * @returns {{ data: DecodedArray[], skipped: number }}
+ * @returns {Promise<{ data: DecodedArray[], skipped: number }>}
  */
-export function readColumn(reader, { groupStart, selectStart, selectEnd }, columnDecoder, onPage) {
+export async function readColumn(reader, { groupStart, selectStart, selectEnd }, columnDecoder, onPage) {
   const { pathInSchema, schemaPath } = columnDecoder
   const isFlat = isFlatColumn(schemaPath)
   /** @type {DecodedArray[]} */
@@ -46,11 +46,11 @@ export function readColumn(reader, { groupStart, selectStart, selectEnd }, colum
     // read page header
     const header = parquetHeader(reader)
     if (header.type === 'DICTIONARY_PAGE') {
-      const { data } = readPage(reader, header, columnDecoder, dictionary, undefined, 0)
+      const { data } = await readPage(reader, header, columnDecoder, dictionary, undefined, 0)
       if (data) dictionary = convert(data, columnDecoder)
     } else {
       const lastChunkLength = lastChunk?.length || 0
-      const result = readPage(reader, header, columnDecoder, dictionary, lastChunk, selectStart - rowCount)
+      const result = await readPage(reader, header, columnDecoder, dictionary, lastChunk, selectStart - rowCount)
       if (result.skipped) {
         // skipped page - just advance row count, don't add to chunks
         if (!chunks.length) {
@@ -82,9 +82,9 @@ export function readColumn(reader, { groupStart, selectStart, selectEnd }, colum
  * @param {DecodedArray | undefined} dictionary
  * @param {DecodedArray | undefined} previousChunk
  * @param {number} pageStart skip this many rows in the page
- * @returns {PageResult}
+ * @returns {Promise<PageResult>}
  */
-export function readPage(reader, header, columnDecoder, dictionary, previousChunk, pageStart) {
+export async function readPage(reader, header, columnDecoder, dictionary, previousChunk, pageStart) {
   const { type, element, schemaPath, codec, compressors } = columnDecoder
   // read compressed_page_size bytes
   const compressedBytes = new Uint8Array(
@@ -102,7 +102,7 @@ export function readPage(reader, header, columnDecoder, dictionary, previousChun
       return { skipped: daph.num_values }
     }
 
-    const page = decompressPage(compressedBytes, Number(header.uncompressed_page_size), codec, compressors)
+    const page = await decompressPage(compressedBytes, Number(header.uncompressed_page_size), codec, compressors)
     const { definitionLevels, repetitionLevels, dataPage } = readDataPage(page, daph, columnDecoder)
     // assert(!daph.statistics?.null_count || daph.statistics.null_count === BigInt(daph.num_values - dataPage.length))
 
@@ -121,7 +121,7 @@ export function readPage(reader, header, columnDecoder, dictionary, previousChun
     }
 
     const { definitionLevels, repetitionLevels, dataPage } =
-      readDataPageV2(compressedBytes, header, columnDecoder)
+      await readDataPageV2(compressedBytes, header, columnDecoder)
 
     // convert types, dereference dictionary, and assemble lists
     const values = convertWithDictionary(dataPage, dictionary, daph2.encoding, columnDecoder)
@@ -132,7 +132,7 @@ export function readPage(reader, header, columnDecoder, dictionary, previousChun
     const diph = header.dictionary_page_header
     if (!diph) throw new Error('parquet dictionary page header is undefined')
 
-    const page = decompressPage(
+    const page = await decompressPage(
       compressedBytes, Number(header.uncompressed_page_size), codec, compressors
     )
 

--- a/src/datapage.js
+++ b/src/datapage.js
@@ -4,6 +4,7 @@
 
 import { deltaBinaryUnpack, deltaByteArray, deltaLengthByteArray } from './delta.js'
 import { byteStreamSplit, readRleBitPackedHybrid } from './encoding.js'
+import { gzipUncompress } from './gzip.js'
 import { readPlain } from './plain.js'
 import { getMaxDefinitionLevel, getMaxRepetitionLevel } from './schema.js'
 import { snappyUncompress } from './snappy.js'
@@ -112,19 +113,21 @@ function readDefinitionLevels(reader, daph, schemaPath) {
  * @param {number} uncompressed_page_size
  * @param {CompressionCodec} codec
  * @param {Compressors | undefined} compressors
- * @returns {Uint8Array}
+ * @returns {Promise<Uint8Array>}
  */
-export function decompressPage(compressedBytes, uncompressed_page_size, codec, compressors) {
+export async function decompressPage(compressedBytes, uncompressed_page_size, codec, compressors) {
   /** @type {Uint8Array} */
   let page
   const customDecompressor = compressors?.[codec]
   if (codec === 'UNCOMPRESSED') {
     page = compressedBytes
   } else if (customDecompressor) {
-    page = customDecompressor(compressedBytes, uncompressed_page_size)
+    page = await customDecompressor(compressedBytes, uncompressed_page_size)
   } else if (codec === 'SNAPPY') {
     page = new Uint8Array(uncompressed_page_size)
     snappyUncompress(compressedBytes, page)
+  } else if (codec === 'GZIP') {
+    page = await gzipUncompress(compressedBytes, uncompressed_page_size)
   } else {
     throw new Error(`parquet unsupported compression codec: ${codec}`)
   }
@@ -141,9 +144,9 @@ export function decompressPage(compressedBytes, uncompressed_page_size, codec, c
  * @param {Uint8Array} compressedBytes raw page data
  * @param {PageHeader} ph page header
  * @param {ColumnDecoder} columnDecoder
- * @returns {DataPage} definition levels, repetition levels, and array of values
+ * @returns {Promise<DataPage>} definition levels, repetition levels, and array of values
  */
-export function readDataPageV2(compressedBytes, ph, columnDecoder) {
+export async function readDataPageV2(compressedBytes, ph, columnDecoder) {
   const view = new DataView(compressedBytes.buffer, compressedBytes.byteOffset, compressedBytes.byteLength)
   const reader = { view, offset: 0 }
   const { type, element, schemaPath, codec, compressors } = columnDecoder
@@ -162,7 +165,7 @@ export function readDataPageV2(compressedBytes, ph, columnDecoder) {
 
   let page = compressedBytes.subarray(reader.offset)
   if (daph2.is_compressed !== false) {
-    page = decompressPage(page, uncompressedPageSize, codec, compressors)
+    page = await decompressPage(page, uncompressedPageSize, codec, compressors)
   }
   const pageView = new DataView(page.buffer, page.byteOffset, page.byteLength)
   const pageReader = { view: pageView, offset: 0 }

--- a/src/gzip.js
+++ b/src/gzip.js
@@ -1,0 +1,27 @@
+/**
+ * Decompress gzip data using the native DecompressionStream API.
+ *
+ * @param {Uint8Array} input compressed data
+ * @param {number} outputLength expected decompressed size
+ * @returns {Promise<Uint8Array>} decompressed data
+ */
+export async function gzipUncompress(input, outputLength) {
+  const stream = new DecompressionStream('gzip')
+  const writer = stream.writable.getWriter()
+  // eslint-disable-next-line no-extra-parens
+  writer.write(/** @type {Uint8Array<ArrayBuffer>} */ (input)).catch(() => {})
+  writer.close().catch(() => {})
+  const output = new Uint8Array(outputLength)
+  let offset = 0
+  const reader = stream.readable.getReader()
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) break
+    if (offset + value.length > outputLength) {
+      throw new Error(`parquet gzip decompressed data exceeds expected length ${outputLength}`)
+    }
+    output.set(value, offset)
+    offset += value.length
+  }
+  return offset === outputLength ? output : output.subarray(0, offset)
+}

--- a/src/rowgroup.js
+++ b/src/rowgroup.js
@@ -85,7 +85,7 @@ export function readRowGroup(options, { metadata }, groupPlan) {
             selectStart: groupPlan.selectStart - skipped,
             selectEnd: groupPlan.selectEnd - skipped,
           } : groupPlan
-          const { data, skipped: columnSkipped } = readColumn(reader, adjustedGroupPlan, columnDecoder, options.onPage)
+          const { data, skipped: columnSkipped } = await readColumn(reader, adjustedGroupPlan, columnDecoder, options.onPage)
           return {
             data,
             skipped: skipped + columnSkipped,

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -276,7 +276,7 @@ export type CompressionCodec =
   | 'LZ4_RAW'
 
 export type Compressors = {
-  [K in CompressionCodec]?: (input: Uint8Array, outputLength: number) => Uint8Array
+  [K in CompressionCodec]?: (input: Uint8Array, outputLength: number) => Awaitable<Uint8Array>
 }
 
 export interface KeyValue {

--- a/test/column.test.js
+++ b/test/column.test.js
@@ -39,7 +39,7 @@ describe('readColumn', () => {
       groupRows: expected.length,
     }
 
-    const result = readColumn(reader, rowGroupSelect, columnDecoder)
+    const result = await readColumn(reader, rowGroupSelect, columnDecoder)
     expect(result.data).toEqual(expected)
   })
 
@@ -70,7 +70,7 @@ describe('readColumn', () => {
       groupRows: Number(column.meta_data.num_values),
     }
 
-    const { data } = readColumn(reader, rowGroupSelect, columnDecoder)
+    const { data } = await readColumn(reader, rowGroupSelect, columnDecoder)
     expect(data[0]).toBeInstanceOf(Int32Array)
   })
 })

--- a/test/gzip.test.js
+++ b/test/gzip.test.js
@@ -1,0 +1,55 @@
+import { gzipSync } from 'zlib'
+import { describe, expect, it } from 'vitest'
+import { gzipUncompress } from '../src/gzip.js'
+import { parquetRead, toJson } from '../src/index.js'
+import { asyncBufferFromFile } from '../src/node.js'
+import { fileToJson } from './helpers.js'
+
+describe('gzipUncompress', () => {
+  it('decompresses a gzip member', async () => {
+    const input = new TextEncoder().encode('hyparquet '.repeat(100))
+    const output = await gzipUncompress(gzipSync(input), input.length)
+    expect(output).toEqual(input)
+  })
+
+  it('decompresses concatenated gzip members', async () => {
+    const a = new TextEncoder().encode('hello ')
+    const b = new TextEncoder().encode('world')
+    const ga = gzipSync(a)
+    const gb = gzipSync(b)
+    const concat = new Uint8Array(ga.length + gb.length)
+    concat.set(ga, 0)
+    concat.set(gb, ga.length)
+    const output = await gzipUncompress(concat, a.length + b.length)
+    expect(new TextDecoder().decode(output)).toBe('hello world')
+  })
+
+  it('throws when output exceeds expected length', async () => {
+    const input = new TextEncoder().encode('hyparquet '.repeat(100))
+    await expect(gzipUncompress(gzipSync(input), 10))
+      .rejects.toThrow('parquet gzip decompressed data exceeds expected length 10')
+  })
+
+  it('rejects on malformed input', async () => {
+    await expect(gzipUncompress(new Uint8Array([1, 2, 3, 4]), 10))
+      .rejects.toThrow()
+  })
+})
+
+describe('parquetRead gzip files without compressors option', () => {
+  it.for([
+    'rle_boolean_encoding.parquet',
+    'concatenated_gzip_members.parquet',
+    'byte_stream_split_extended.gzip.parquet',
+  ])('parse data from %s', async filename => {
+    const file = await asyncBufferFromFile(`test/files/${filename}`)
+    await parquetRead({
+      file,
+      onComplete(rows) {
+        const base = filename.replace('.parquet', '')
+        const expected = fileToJson(`test/files/${base}.json`)
+        expect(JSON.parse(JSON.stringify(toJson(rows)))).toEqual(expected)
+      },
+    })
+  })
+})

--- a/test/read.test.js
+++ b/test/read.test.js
@@ -461,9 +461,16 @@ describe('parquetRead', () => {
   })
 
   it('requires compressors for compressed files', async () => {
-    const file = await asyncBufferFromFile('test/files/rle_boolean_encoding.parquet')
+    const file = await asyncBufferFromFile('test/files/brotli_compressed.parquet')
     await expect(parquetReadObjects({ file }))
-      .rejects.toThrow('parquet unsupported compression codec: GZIP')
+      .rejects.toThrow('parquet unsupported compression codec: BROTLI')
+  })
+
+  it('reads gzip files without external compressors', async () => {
+    const file = await asyncBufferFromFile('test/files/rle_boolean_encoding.parquet')
+    const rows = await parquetReadObjects({ file })
+    expect(rows.length).toBe(68)
+    expect(rows[0]).toEqual({ datatype_boolean: true })
   })
 
   it('does not leak unhandled rejections when a row group read fails', async () => {


### PR DESCRIPTION
Browser have gzip natively, so I was wondering if we can actually use that for native gzip support on parquet. Yes we can! But it does require changing some internal APIs for async. WDYT? 

This lets the browser transfer large parquet files effeciently without the bloat of implementing a decompression codec.