### PR TITLE
Support $in filters on array values

### DIFF
--- a/src/filter.js
+++ b/src/filter.js
@@ -73,12 +73,26 @@ export function matchFilter(record, filter, strict = true) {
       if (operator === '$lte') return value <= target
       if (operator === '$eq') return equals(value, target, strict)
       if (operator === '$ne') return !equals(value, target, strict)
-      if (operator === '$in') return Array.isArray(target) && target.includes(value)
-      if (operator === '$nin') return Array.isArray(target) && !target.includes(value)
+      if (operator === '$in') return Array.isArray(target) && matchesIn(value, target, strict)
+      if (operator === '$nin') return Array.isArray(target) && !matchesIn(value, target, strict)
       if (operator === '$not') return !matchFilter({ [field]: value }, { [field]: target }, strict)
       return true
     })
   })
+}
+
+/**
+ * Match a value or one of its immediate array elements against a list.
+ *
+ * @param {any} value
+ * @param {any[]} targets
+ * @param {boolean} strict
+ * @returns {boolean}
+ */
+function matchesIn(value, targets, strict) {
+  return targets.some(target =>
+    equals(value, target, strict) ||
+    Array.isArray(value) && value.some(element => equals(element, target, strict)))
 }
 
 /**

--- a/test/filter.test.js
+++ b/test/filter.test.js
@@ -46,6 +46,16 @@ describe('matchFilter', () => {
     expect(matchFilter(record, { x: { $not: { $lt: 10 } } })).toBe(false)
   })
 
+  it('handles $in and $nin with array values', () => {
+    const record = { x: [['a', 'b'], 'c'] }
+    expect(matchFilter(record, { x: { $in: ['c'] } })).toBe(true)
+    expect(matchFilter(record, { x: { $in: ['a'] } })).toBe(false)
+    expect(matchFilter(record, { x: { $in: [['a', 'b']] } })).toBe(true)
+    expect(matchFilter(record, { x: { $in: [[['a', 'b'], 'c']] } })).toBe(true)
+    expect(matchFilter(record, { x: { $nin: ['a'] } })).toBe(true)
+    expect(matchFilter(record, { x: { $nin: ['c'] } })).toBe(false)
+  })
+
   it('uses strict equality (===) when strict is true', () => {
     expect(matchFilter({ x: 5 }, { x: { $eq: '5' } }, true)).toBe(false)
     expect(matchFilter({ x: 5 }, { x: { $ne: '5' } }, true)).toBe(true)


### PR DESCRIPTION
Extend `$in` to match either the complete field value or an immediate array element. Follows mongo semantics for arrays.

- Matches scalar values and immediate array elements.
- Matches nested arrays as atomic values.
- Does not recursively flatten nested arrays.

Fixes #170 
